### PR TITLE
audioipc: Specify explicit length when configuring MmapMut on both sides of remote.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -33,7 +33,7 @@ audio_thread_priority = "0.23.4"
 winapi = { version = "0.3", features = ["combaseapi", "memoryapi", "objbase"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ashmem = "0.1"
+ashmem = "0.1.2"
 
 [dependencies.error-chain]
 version = "0.11.0"

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -196,7 +196,7 @@ mod unix {
     impl SharedMem {
         pub fn new(id: &str, size: usize) -> Result<SharedMem> {
             let file = open_shm_file(id, size)?;
-            let mut mmap = unsafe { MmapOptions::new().map_mut(&file)? };
+            let mut mmap = unsafe { MmapOptions::new().len(size).map_mut(&file)? };
             assert_eq!(mmap.len(), size);
             let view = SharedMemView {
                 ptr: mmap.as_mut_ptr() as _,
@@ -215,7 +215,7 @@ mod unix {
 
         pub unsafe fn from(handle: PlatformHandle, size: usize) -> Result<SharedMem> {
             let file = File::from_raw_fd(handle.into_raw());
-            let mut mmap = MmapOptions::new().map_mut(&file)?;
+            let mut mmap = MmapOptions::new().len(size).map_mut(&file)?;
             assert_eq!(mmap.len(), size);
             let view = SharedMemView {
                 ptr: mmap.as_mut_ptr() as _,


### PR DESCRIPTION
Also bump ashmem to 0.1.2, which contains minor fixes for Android.

Without an explicit length set on `MmapOptions`, [`mmap_mut`](https://github.com/RazrFalcon/memmap2-rs/blob/master/src/lib.rs#L398) tries to query the [file length](https://github.com/RazrFalcon/memmap2-rs/blob/master/src/lib.rs#L240), which results in an attempt to call [`fstat`](https://github.com/RazrFalcon/memmap2-rs/blob/master/src/unix.rs#L278).  This fails on file descriptors supplied by Android's ashmem, causing shared memory setup to fail.

Since we already know the expected size of the mapping we can set the length explicitly and avoid the `fstat`.

This also solves [bug 1747932](https://bugzilla.mozilla.org/show_bug.cgi?id=1747932) for macOS 10.13, where the `fstat` is blocked by the content sandbox.