### PR TITLE
Handle up to 2 fds per decoded `cmsghdr` buffer.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -25,6 +25,7 @@ scopeguard = "1.1.0"
 iovec = "0.1"
 libc = "0.2"
 memmap2 = "0.2"
+arrayvec = "0.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 audio_thread_priority = "0.23.4"

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -606,9 +606,9 @@ where
                 if let Some(handle) = self.extra_handle.take() {
                     unsafe { handle.into_raw() }
                 } else {
-                    let (handle, extra_handle) = cmsg::decode_handles(&mut inbound.cmsg);
-                    self.extra_handle = extra_handle.map(PlatformHandle::new);
-                    handle
+                    let handles = cmsg::decode_handles(&mut inbound.cmsg);
+                    self.extra_handle = handles.get(1).map(|h| PlatformHandle::new(*h));
+                    handles[0]
                 }
             });
             self.handler.consume(item)?;

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -25,6 +25,8 @@ use std::fmt::Debug;
 use crate::duplicate_platform_handle;
 #[cfg(unix)]
 use crate::sys::cmsg;
+#[cfg(unix)]
+use crate::PlatformHandle;
 
 const WAKE_TOKEN: Token = Token(!0);
 
@@ -600,7 +602,15 @@ where
         #[allow(unused_mut)]
         while let Some(mut item) = self.codec.decode(&mut inbound.buf)? {
             #[cfg(unix)]
-            item.receive_owned_message_handle(|| cmsg::decode_handle(&mut inbound.cmsg));
+            item.receive_owned_message_handle(|| {
+                if let Some(handle) = self.extra_handle.take() {
+                    unsafe { handle.into_raw() }
+                } else {
+                    let (handle, extra_handle) = cmsg::decode_handles(&mut inbound.cmsg);
+                    self.extra_handle = extra_handle.map(PlatformHandle::new);
+                    handle
+                }
+            });
             self.handler.consume(item)?;
         }
 
@@ -636,6 +646,8 @@ where
 struct FramedDriver<T: Handler> {
     codec: LengthDelimitedCodec<T::Out, T::In>,
     handler: T,
+    #[cfg(unix)]
+    extra_handle: Option<PlatformHandle>,
 }
 
 impl<T: Handler> FramedDriver<T> {
@@ -643,6 +655,8 @@ impl<T: Handler> FramedDriver<T> {
         FramedDriver {
             codec: Default::default(),
             handler,
+            #[cfg(unix)]
+            extra_handle: None,
         }
     }
 }

--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -425,6 +425,7 @@ pub trait AssociateHandleForMessage {
 
     // Update the item's handle with the received value, making it a valid owned handle.
     // Called on the receiving side after deserialization.
+    // Implementations must only call `F` for message types expecting a handle.
     #[cfg(unix)]
     fn receive_owned_message_handle<F>(&mut self, _: F)
     where

--- a/audioipc/src/sys/unix/mod.rs
+++ b/audioipc/src/sys/unix/mod.rs
@@ -133,9 +133,12 @@ impl Drop for ConnectionBuffer {
 
 fn close_fds(cmsg: &mut BytesMut) {
     while !cmsg.is_empty() {
-        let fd = cmsg::decode_handle(cmsg);
+        let (fd, extra_fd) = cmsg::decode_handles(cmsg);
         unsafe {
             close_platform_handle(fd);
+            if let Some(fd) = extra_fd {
+                close_platform_handle(fd);
+            }
         }
     }
     assert!(cmsg.is_empty());

--- a/audioipc/src/sys/unix/mod.rs
+++ b/audioipc/src/sys/unix/mod.rs
@@ -133,10 +133,9 @@ impl Drop for ConnectionBuffer {
 
 fn close_fds(cmsg: &mut BytesMut) {
     while !cmsg.is_empty() {
-        let (fd, extra_fd) = cmsg::decode_handles(cmsg);
-        unsafe {
-            close_platform_handle(fd);
-            if let Some(fd) = extra_fd {
+        let fds = cmsg::decode_handles(cmsg);
+        for fd in fds {
+            unsafe {
                 close_platform_handle(fd);
             }
         }


### PR DESCRIPTION
This isn't the most elegant fix, but it's a fiddly issue.  I may revisit this again later if I think of a cleaner way to handle it.

On some 64-bit platforms, due to struct alignment requirements, the smallest `cmsghdr` has capacity for 2 fds even if only 1 is expected/requested.  Due to buffer coalescing, multiple `sendmsg` calls may arrive via a single `recvmsg`, resulting in a situation where the `cmsghdr` contains multiple (maximum 2) fds.

This addresses [BMO 1750345](https://bugzilla.mozilla.org/show_bug.cgi?id=1750345).