### PR TITLE
Use separate rpc Proxy clones for each of ServerStreamCallbacks's callbacks.

### DIFF
--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -178,12 +178,6 @@ pub(crate) fn make_client<C: Client>(
         in_flight: VecDeque::with_capacity(32),
     };
 
-    // Sender is Send, but !Sync, so it's not safe to move between threads
-    // without cloning it first.  Force a clone here, since we use Proxy in
-    // native code and it's possible to move it between threads without Rust's
-    // type system noticing.
-    #[allow(clippy::redundant_clone)]
-    let tx = tx.clone();
     let proxy = Proxy {
         handle: None,
         tx: ManuallyDrop::new(tx),


### PR DESCRIPTION
The threads that cubeb executes the data, state, and device_change
callbacks on is undefined. Using a single rpc Proxy for all three of the
ServerStreamCallbacks callbacks can result in the Proxy being used from
multiple threads concurrently (e.g. data_callback on the OS audio
thread and state_callback on the Server RPC thread) depending on the
cubeb backend in use.

Also remove the mpsc::channel clone from make_client, since it was
obscuring the root cause of this issue.