### PR TITLE
Don't try to wake_connection in Proxy::drop if event loop was never connected.

### DIFF
--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -113,7 +113,9 @@ impl<Request, Response> Drop for Proxy<Request, Response> {
         // Must drop Sender before waking the connection, otherwise
         // the wake may be processed before Sender is closed.
         unsafe { ManuallyDrop::drop(&mut self.tx) }
-        self.wake_connection();
+        if self.handle.is_some() {
+            self.wake_connection()
+        }
     }
 }
 


### PR DESCRIPTION
Fixes a potential crash if Proxy is ever dropped before
connect_event_loop is called.  This can happen in
EventLoopHandle::bind_client if add_connection fails.