### PR TITLE
Simplify stream SharedMem configuration between server/client.

### DIFF
--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -188,7 +188,8 @@ fn opt_str(v: Option<Vec<u8>>) -> *mut c_char {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StreamCreate {
     pub token: usize,
-    pub platform_handle: SerializableHandle,
+    pub shm_handle: SerializableHandle,
+    pub shm_area_size: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -246,7 +247,7 @@ pub enum ClientMessage {
     ContextRegisteredDeviceCollectionChanged,
 
     StreamCreated(StreamCreate),
-    StreamInitialized,
+    StreamInitialized(SerializableHandle),
     StreamDestroyed,
 
     StreamStarted,
@@ -274,7 +275,6 @@ pub enum CallbackReq {
     },
     State(ffi::cubeb_state),
     DeviceChange,
-    SharedMem(SerializableHandle, usize),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -282,7 +282,6 @@ pub enum CallbackResp {
     Data(isize),
     State,
     DeviceChange,
-    SharedMem,
     Error(c_int),
 }
 
@@ -443,13 +442,22 @@ impl AssociateHandleForMessage for ClientMessage {
         unsafe {
             match *self {
                 ClientMessage::StreamCreated(ref mut data) => {
-                    let handle = data.platform_handle.take_handle_for_send();
-                    data.platform_handle =
+                    let handle = data.shm_handle.take_handle_for_send();
+                    data.shm_handle =
                         SerializableHandle::new_serializable_value(f(handle.0, handle.1)?);
                     trace!(
                         "StreamCreated handle: {:?} remote_handle: {:?}",
                         handle,
-                        data.platform_handle
+                        data.shm_handle
+                    );
+                }
+                ClientMessage::StreamInitialized(ref mut data) => {
+                    let handle = data.take_handle_for_send();
+                    *data = SerializableHandle::new_serializable_value(f(handle.0, handle.1)?);
+                    trace!(
+                        "StreamInitialized handle: {:?} remote_handle: {:?}",
+                        handle,
+                        data
                     );
                 }
                 ClientMessage::ContextSetupDeviceCollectionCallback(ref mut data) => {
@@ -475,7 +483,10 @@ impl AssociateHandleForMessage for ClientMessage {
     {
         match *self {
             ClientMessage::StreamCreated(ref mut data) => {
-                data.platform_handle = SerializableHandle::new_owned(f());
+                data.shm_handle = SerializableHandle::new_owned(f());
+            }
+            ClientMessage::StreamInitialized(ref mut data) => {
+                *data = SerializableHandle::new_owned(f());
             }
             ClientMessage::ContextSetupDeviceCollectionCallback(ref mut data) => {
                 data.platform_handle = SerializableHandle::new_owned(f());
@@ -488,32 +499,7 @@ impl AssociateHandleForMessage for ClientMessage {
 impl AssociateHandleForMessage for DeviceCollectionReq {}
 impl AssociateHandleForMessage for DeviceCollectionResp {}
 
-impl AssociateHandleForMessage for CallbackReq {
-    fn prepare_send_message_handle<F>(&mut self, f: F) -> io::Result<()>
-    where
-        F: FnOnce(PlatformHandleType, u32) -> io::Result<PlatformHandleType>,
-    {
-        unsafe {
-            if let CallbackReq::SharedMem(ref mut data, _) = *self {
-                let handle = data.take_handle_for_send();
-                *data = SerializableHandle::new_serializable_value(f(handle.0, handle.1)?);
-                trace!("SharedMem handle: {:?} remote_handle: {:?}", handle, data);
-            }
-        }
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    fn receive_owned_message_handle<F>(&mut self, f: F)
-    where
-        F: FnOnce() -> PlatformHandleType,
-    {
-        if let CallbackReq::SharedMem(ref mut data, _) = *self {
-            *data = SerializableHandle::new_owned(f());
-        }
-    }
-}
-
+impl AssociateHandleForMessage for CallbackReq {}
 impl AssociateHandleForMessage for CallbackResp {}
 
 #[cfg(test)]

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -15,7 +15,7 @@ pub use unix::SharedMem;
 pub use windows::SharedMem;
 
 #[derive(Copy, Clone)]
-pub struct SharedMemView {
+struct SharedMemView {
     ptr: *mut c_void,
     size: usize,
 }
@@ -228,10 +228,6 @@ mod unix {
             })
         }
 
-        pub unsafe fn unsafe_view(&self) -> SharedMemView {
-            self.view
-        }
-
         pub unsafe fn get_slice(&self, size: usize) -> Result<&[u8]> {
             self.view.get_slice(size)
         }
@@ -317,10 +313,6 @@ mod windows {
                 handle,
                 view: SharedMemView { ptr, size },
             })
-        }
-
-        pub unsafe fn unsafe_view(&self) -> SharedMemView {
-            self.view
         }
 
         pub unsafe fn get_slice(&self, size: usize) -> Result<&[u8]> {

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -46,16 +46,8 @@ pub struct ClientStream<'ctx> {
     shutdown_rx: mpsc::Receiver<()>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum StreamDirection {
-    Input,
-    Output,
-    Duplex,
-}
-
 struct CallbackServer {
-    dir: StreamDirection,
-    shm: Option<SharedMem>,
+    shm: SharedMem,
     duplex_input: Option<Vec<u8>>,
     data_cb: ffi::cubeb_data_callback,
     state_cb: ffi::cubeb_state_callback,
@@ -87,11 +79,10 @@ impl rpccore::Server for CallbackServer {
                 let output_nbytes = nframes as usize * output_frame_size;
 
                 // Clone values that need to be moved into the cpu pool thread.
-                let mut shm = unsafe { self.shm.as_ref().unwrap().unsafe_view() };
+                let mut shm = unsafe { self.shm.unsafe_view() };
 
                 let duplex_copy_ptr = match &mut self.duplex_input {
                     Some(buf) => {
-                        assert_eq!(self.dir, StreamDirection::Duplex);
                         assert!(input_frame_size > 0);
                         assert!(buf.capacity() >= input_nbytes);
                         buf.as_mut_ptr()
@@ -100,16 +91,29 @@ impl rpccore::Server for CallbackServer {
                 } as usize;
                 let user_ptr = self.user_ptr;
                 let cb = self.data_cb.unwrap();
-                let dir = self.dir;
 
                 // Input and output reuse the same shmem backing.  Unfortunately, cubeb's data_callback isn't
                 // specified in such a way that would require the callee to consume all of the input before
                 // writing to the output (i.e., it is passed as two pointers that aren't expected to alias).
                 // That means we need to copy the input here.
-                let (input_ptr, output_ptr) = match dir {
-                    StreamDirection::Duplex => unsafe {
-                        assert!(input_frame_size > 0);
-                        assert!(output_frame_size > 0);
+                let (input_ptr, output_ptr) = match (input_frame_size, output_frame_size) {
+                    // Input-only.
+                    (input_frame_size, 0) if input_frame_size > 0 => unsafe {
+                        (
+                            shm.get_slice(input_nbytes).unwrap().as_ptr(),
+                            ptr::null_mut(),
+                        )
+                    },
+                    // Output-only.
+                    (0, output_frame_size) if output_frame_size > 0 => unsafe {
+                        (
+                            ptr::null(),
+                            shm.get_mut_slice(output_nbytes).unwrap().as_mut_ptr(),
+                        )
+                    },
+                    // Duplex, copy shmem to duplex_copy.
+                    (input_frame_size, output_frame_size) => unsafe {
+                        assert!(input_frame_size > 0 && output_frame_size > 0);
                         assert_ne!(duplex_copy_ptr, 0);
                         let input = shm.get_slice(input_nbytes).unwrap();
                         ptr::copy_nonoverlapping(
@@ -119,22 +123,6 @@ impl rpccore::Server for CallbackServer {
                         );
                         (
                             duplex_copy_ptr as _,
-                            shm.get_mut_slice(output_nbytes).unwrap().as_mut_ptr(),
-                        )
-                    },
-                    StreamDirection::Input => unsafe {
-                        assert!(input_frame_size > 0);
-                        assert_eq!(output_frame_size, 0);
-                        (
-                            shm.get_slice(input_nbytes).unwrap().as_ptr(),
-                            ptr::null_mut(),
-                        )
-                    },
-                    StreamDirection::Output => unsafe {
-                        assert!(output_frame_size > 0);
-                        assert_eq!(input_frame_size, 0);
-                        (
-                            ptr::null(),
                             shm.get_mut_slice(output_nbytes).unwrap().as_mut_ptr(),
                         )
                     },
@@ -180,35 +168,6 @@ impl rpccore::Server for CallbackServer {
 
                 CallbackResp::DeviceChange
             }
-            CallbackReq::SharedMem(mut handle, shm_area_size) => {
-                self.shm = match unsafe { SharedMem::from(handle.take_handle(), shm_area_size) } {
-                    Ok(shm) => Some(shm),
-                    Err(e) => {
-                        warn!(
-                            "sharedmem client mapping failed (size={}, err={:?})",
-                            shm_area_size, e
-                        );
-                        return CallbackResp::Error(ffi::CUBEB_ERROR);
-                    }
-                };
-
-                self.duplex_input = if let StreamDirection::Duplex = self.dir {
-                    let mut duplex_input = Vec::new();
-                    match duplex_input.try_reserve_exact(shm_area_size) {
-                        Ok(()) => Some(duplex_input),
-                        Err(e) => {
-                            warn!(
-                                "duplex_input allocation failed (size={}, err={:?})",
-                                shm_area_size, e
-                            );
-                            return CallbackResp::Error(ffi::CUBEB_ERROR);
-                        }
-                    }
-                } else {
-                    None
-                };
-                CallbackResp::SharedMem
-            }
         }
     }
 }
@@ -231,11 +190,44 @@ impl<'ctx> ClientStream<'ctx> {
         let mut data = send_recv!(rpc, StreamCreate(create_params) => StreamCreated())?;
 
         debug!(
-            "token = {}, handle = {:?}",
-            data.token, data.platform_handle
+            "token = {}, handle = {:?} area_size = {:?}",
+            data.token, data.shm_handle, data.shm_area_size
         );
 
-        let stream = unsafe { sys::Pipe::from_raw_handle(data.platform_handle.take_handle()) };
+        let shm =
+            match unsafe { SharedMem::from(data.shm_handle.take_handle(), data.shm_area_size) } {
+                Ok(shm) => shm,
+                Err(e) => {
+                    warn!(
+                        "SharedMem client mapping failed (size={}, err={:?})",
+                        data.shm_area_size, e
+                    );
+                    return Err(Error::default());
+                }
+            };
+
+        let duplex_input = if let (Some(_), Some(_)) = (
+            init_params.input_stream_params,
+            init_params.output_stream_params,
+        ) {
+            let mut duplex_input = Vec::new();
+            match duplex_input.try_reserve_exact(data.shm_area_size) {
+                Ok(()) => Some(duplex_input),
+                Err(e) => {
+                    warn!(
+                        "duplex_input allocation failed (size={}, err={:?})",
+                        data.shm_area_size, e
+                    );
+                    return Err(Error::default());
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut stream =
+            send_recv!(rpc, StreamInit(data.token, init_params) => StreamInitialized())?;
+        let stream = unsafe { sys::Pipe::from_raw_handle(stream.take_handle()) };
 
         let user_data = user_ptr as usize;
 
@@ -244,20 +236,9 @@ impl<'ctx> ClientStream<'ctx> {
 
         let (_shutdown_tx, shutdown_rx) = mpsc::channel();
 
-        let dir = match (
-            init_params.input_stream_params,
-            init_params.output_stream_params,
-        ) {
-            (Some(_), Some(_)) => StreamDirection::Duplex,
-            (Some(_), None) => StreamDirection::Input,
-            (None, Some(_)) => StreamDirection::Output,
-            (None, None) => unreachable!(),
-        };
-
         let server = CallbackServer {
-            dir,
-            shm: None,
-            duplex_input: None,
+            shm,
+            duplex_input,
             data_cb: data_callback,
             state_cb: state_callback,
             user_ptr: user_data,
@@ -268,8 +249,6 @@ impl<'ctx> ClientStream<'ctx> {
         ctx.callback_handle()
             .bind_server(server, stream)
             .map_err(|_| Error::default())?;
-
-        send_recv!(rpc, StreamInit(data.token, init_params) => StreamInitialized)?;
 
         let stream = Box::into_raw(Box::new(ClientStream {
             context: ctx,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -12,7 +12,7 @@ use audioipc::messages::{
     StreamInitParams, StreamParams,
 };
 use audioipc::shm::SharedMem;
-use audioipc::{ipccore, rpccore, sys};
+use audioipc::{ipccore, rpccore, sys, PlatformHandle};
 use cubeb_core as cubeb;
 use cubeb_core::ffi;
 use std::convert::From;
@@ -310,7 +310,7 @@ fn get_shm_id() -> String {
 struct ServerStream {
     stream: Option<cubeb::Stream>,
     cbs: Box<ServerStreamCallbacks>,
-    shm_setup: Option<rpccore::ProxyResponse<CallbackResp>>,
+    client_pipe: Option<PlatformHandle>,
 }
 
 impl Drop for ServerStream {
@@ -688,12 +688,6 @@ impl CubebServer {
             .callback_thread
             .bind_client::<CallbackClient>(server_pipe)?;
 
-        // Send shm configuration to client but don't wait for result; that'll be checked in process_stream_init.
-        let shm_setup = Some(rpc.call(CallbackReq::SharedMem(
-            SerializableHandle::new(shm_handle, self.remote_pid.unwrap()),
-            shm_area_size,
-        )));
-
         let cbs = Box::new(ServerStreamCallbacks {
             input_frame_size,
             output_frame_size,
@@ -707,13 +701,14 @@ impl CubebServer {
 
         entry.insert(ServerStream {
             stream: None,
-            shm_setup,
             cbs,
+            client_pipe: Some(client_pipe),
         });
 
         Ok(ClientMessage::StreamCreated(StreamCreate {
             token: key,
-            platform_handle: SerializableHandle::new(client_pipe, self.remote_pid.unwrap()),
+            shm_handle: SerializableHandle::new(shm_handle, self.remote_pid.unwrap()),
+            shm_area_size,
         }))
     }
 
@@ -748,38 +743,6 @@ impl CubebServer {
         assert!(size_of::<Box<ServerStreamCallbacks>>() == size_of::<usize>());
         let user_ptr = server_stream.cbs.as_ref() as *const ServerStreamCallbacks as *mut c_void;
 
-        // SharedMem setup message should've been processed by client by now.
-        let shm_setup = server_stream
-            .shm_setup
-            .take()
-            .expect("invalid shm_setup state");
-        match shm_setup.wait() {
-            Ok(CallbackResp::SharedMem) => {}
-            Ok(CallbackResp::Error(e)) => {
-                // If the client replied with an error (e.g. client OOM), log error and fail stream init.
-                debug!(
-                    "Shmem setup for stream {:?} failed (raw error {:?})",
-                    stm_tok, e
-                );
-                return Ok(ClientMessage::Error(e));
-            }
-            Ok(r) => {
-                debug!(
-                    "Shmem setup for stream {:?} failed (unexpected response {:?})",
-                    stm_tok, r
-                );
-                return Ok(error(cubeb::Error::error()));
-            }
-            Err(e) => {
-                // If the client errored before responding, log error and fail stream init.
-                debug!(
-                    "Shmem setup for stream {:?} failed (error {:?})",
-                    stm_tok, e
-                );
-                return Err(e.into());
-            }
-        }
-
         let stream = unsafe {
             let stream = context.stream_init(
                 stream_name,
@@ -804,7 +767,14 @@ impl CubebServer {
 
         server_stream.stream = Some(stream);
 
-        Ok(ClientMessage::StreamInitialized)
+        let client_pipe = server_stream
+            .client_pipe
+            .take()
+            .expect("invalid state after StreamCreated");
+        Ok(ClientMessage::StreamInitialized(SerializableHandle::new(
+            client_pipe,
+            self.remote_pid.unwrap(),
+        )))
     }
 }
 


### PR DESCRIPTION
By slightly reordering the initialization steps in
StreamCreate/StreamInit, it's possible to pass both the SharedMem handle
and callback RPC pipe via client RPC during stream creation.  This
avoids the client callback thread having to handle the SharedMem
messages as part of the initialization sequence.

The second commit cleans up some code in CallbackServer::process left over
from AudioIPC v1 requirements.