### PR TITLE
Update macos branch to audio_thread_priority 0.26.0 and cubeb-rs 0.10.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -27,8 +27,10 @@ libc = "0.2"
 memmap2 = "0.2"
 arrayvec = "0.7"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-audio_thread_priority = "0.23.4"
+[target.'cfg(target_os = "linux")'.dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["combaseapi", "memoryapi", "objbase"] }

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3"
 bytes = "0.4"
-cubeb = "0.9"
+cubeb = "0.10"
 log = "0.4"
 serde = "1"
 serde_derive = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,7 +10,11 @@ description = "Cubeb Backend for talking to remote cubeb server."
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.23.4"
 audioipc = { package = "audioipc2", path="../audioipc" }
 cubeb-backend = "0.9"
 log = "0.4"
+
+[dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { package = "audioipc2", path="../audioipc" }
-cubeb-backend = "0.9"
+cubeb-backend = "0.10"
 log = "0.4"
 
 [dependencies.audio_thread_priority]

--- a/client/src/send_recv.rs
+++ b/client/src/send_recv.rs
@@ -12,7 +12,7 @@ where
     E: Into<Option<c_int>>,
 {
     match e.into() {
-        Some(e) => unsafe { Error::from_raw(e) },
+        Some(e) => Error::from_raw(e),
         None => Error::error(),
     }
 }

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 audioipc = { package = "audioipc2", path = "../audioipc" }
 audioipc-client= { package = "audioipc2-client", path = "../client" }
 audioipc-server = { package = "audioipc2-server", path = "../server" }
-cubeb = "0.9.0"
+cubeb = "0.10.0"
 env_logger = "0.9"
 error-chain = "0.11.0"
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { package = "audioipc2", path = "../audioipc" }
-cubeb-core = "0.9.0"
+cubeb-core = "0.10.0"
 once_cell = "1.2.0"
 log = "0.4"
 slab = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,6 @@ description = "Remote cubeb server"
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.23.4"
 audioipc = { package = "audioipc2", path = "../audioipc" }
 cubeb-core = "0.9.0"
 once_cell = "1.2.0"
@@ -20,3 +19,8 @@ slab = "0.4"
 [dependencies.error-chain]
 version = "0.11.0"
 default-features = false
+
+[dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]


### PR DESCRIPTION
This uses the "winapi" feature flag to continue building against
"winapi" rather than using "windows-rs".

See https://github.com/padenot/audio_thread_priority/pull/13