### PR TITLE
Update tokio branch to audio_thread_priority 0.26.0 and cubeb-rs 0.10.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3"
 bytes = "0.4"
-cubeb = "0.9"
+cubeb = "0.10"
 futures = "0.1.29"
 log = "0.4"
 serde = "1"

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -19,7 +19,6 @@ serde = "1"
 serde_derive = "1"
 tokio = "0.1"
 tokio-io = "0.1"
-audio_thread_priority = "0.23.4"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"
@@ -28,6 +27,11 @@ mio = "0.6.19"
 mio-uds = "0.6.7"
 tokio-reactor = "0.1"
 memmap2 = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]
 
 [target.'cfg(windows)'.dependencies]
 mio = "0.6.19"

--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -105,9 +105,10 @@ impl PlatformHandle {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
     #[cfg(windows)]
-    pub fn duplicate(h: PlatformHandleType) -> Result<PlatformHandle, std::io::Error> {
-        let dup = unsafe { duplicate_platform_handle(h, None) }?;
+    pub unsafe fn duplicate(h: PlatformHandleType) -> Result<PlatformHandle, std::io::Error> {
+        let dup = duplicate_platform_handle(h, None)?;
         Ok(PlatformHandle::new(dup))
     }
 }

--- a/audioipc/src/tokio_uds_stream.rs
+++ b/audioipc/src/tokio_uds_stream.rs
@@ -157,7 +157,7 @@ impl AsyncRead for UnixStream {
     }
 
     fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
-        <&UnixStream>::read_buf(&mut &*self, buf)
+        tokio_io::AsyncRead::read_buf(&mut &*self, buf)
     }
 }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { path="../audioipc" }
-cubeb-backend = "0.9"
+cubeb-backend = "0.10"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }
 futures-cpupool = { version="0.1.8", default-features=false }
 log = "0.4"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,10 +10,14 @@ description = "Cubeb Backend for talking to remote cubeb server."
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.23.4"
 audioipc = { path="../audioipc" }
 cubeb-backend = "0.9"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }
 futures-cpupool = { version="0.1.8", default-features=false }
 log = "0.4"
 tokio = "0.1"
+
+[dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]

--- a/client/src/send_recv.rs
+++ b/client/src/send_recv.rs
@@ -12,7 +12,7 @@ where
     E: Into<Option<c_int>>,
 {
     match e.into() {
-        Some(e) => unsafe { Error::from_raw(e) },
+        Some(e) => Error::from_raw(e),
         None => Error::error(),
     }
 }

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 audioipc = { path = "../audioipc" }
 audioipc-client= { path = "../client" }
 audioipc-server = { path = "../server" }
-cubeb = "0.9.0"
+cubeb = "0.10.0"
 env_logger = "0.4.3"
 error-chain = "0.11.0"
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { path = "../audioipc" }
-cubeb-core = "0.9.0"
+cubeb-core = "0.10.0"
 futures = "0.1.29"
 once_cell = "1.2.0"
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,6 @@ description = "Remote cubeb server"
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.23.4"
 audioipc = { path = "../audioipc" }
 cubeb-core = "0.9.0"
 futures = "0.1.29"
@@ -22,3 +21,8 @@ tokio = "0.1"
 [dependencies.error-chain]
 version = "0.11.0"
 default-features = false
+
+[dependencies.audio_thread_priority]
+version = "0.26.0"
+default_features = false
+features = ["winapi"]


### PR DESCRIPTION
This uses the "winapi" feature flag to continue building against
"winapi" rather than using "windows-rs".

See https://github.com/padenot/audio_thread_priority/pull/13

Also includes two small fixes for CI failures.