### PR TITLE
server: Validity check input/output against shm limit.

### DIFF
--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -235,6 +235,10 @@ mod unix {
         pub unsafe fn get_mut_slice(&mut self, size: usize) -> Result<&mut [u8]> {
             self.view.get_mut_slice(size)
         }
+
+        pub fn get_size(&self) -> usize {
+            self.view.size
+        }
     }
 }
 
@@ -321,6 +325,10 @@ mod windows {
 
         pub unsafe fn get_mut_slice(&mut self, size: usize) -> Result<&mut [u8]> {
             self.view.get_mut_slice(size)
+        }
+
+        pub fn get_size(&self) -> usize {
+            self.view.size
         }
     }
 }


### PR DESCRIPTION
Rather than hit an unwrap accessing the shm slice, validate the input/output slice length against the shm's maximum size and log/return error if invalid.