### PR TITLE
Reduce per-call RPC overhead

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -21,6 +21,7 @@ serde_bytes = "0.11"
 mio = { version = "0.8",  features = ["os-poll", "net", "os-ext"] }
 slab = "0.4"
 scopeguard = "1.1.0"
+crossbeam = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -21,7 +21,7 @@ serde_bytes = "0.11"
 mio = { version = "0.8",  features = ["os-poll", "net", "os-ext"] }
 slab = "0.4"
 scopeguard = "1.1.0"
-crossbeam = "0.8"
+crossbeam-channel = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -7,7 +7,7 @@ use std::io::{self, Result};
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-use crossbeam::channel::{self, Receiver, Sender};
+use crossbeam_channel::{self, Receiver, Sender};
 use mio::{event::Event, Events, Interest, Poll, Registry, Token, Waker};
 use slab::Slab;
 
@@ -152,7 +152,7 @@ impl EventLoop {
     fn new(name: String) -> Result<EventLoop> {
         let poll = Poll::new()?;
         let waker = Arc::new(Waker::new(poll.registry(), WAKE_TOKEN)?);
-        let (tx, rx) = channel::bounded(EVENT_LOOP_INITIAL_CLIENTS);
+        let (tx, rx) = crossbeam_channel::bounded(EVENT_LOOP_INITIAL_CLIENTS);
         let eventloop = EventLoop {
             poll,
             events: Events::with_capacity(EVENT_LOOP_EVENTS_PER_ITERATION),

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -824,7 +824,7 @@ mod test {
 
         // RPC message from client to server.
         let response = client_proxy.call(TestServerMessage::TestRequest);
-        let response = response.wait().expect("client response");
+        let response = response.expect("client response");
         assert_eq!(response, TestClientMessage::TestResponse);
 
         // Explicit shutdown.
@@ -840,7 +840,7 @@ mod test {
 
         // RPC message from client to server.
         let response = client_proxy.call(TestServerMessage::TestRequest);
-        let response = response.wait().expect("client response");
+        let response = response.expect("client response");
         assert_eq!(response, TestClientMessage::TestResponse);
 
         // Explicit shutdown.
@@ -855,7 +855,7 @@ mod test {
         drop(server);
 
         let response = client_proxy.call(TestServerMessage::TestRequest);
-        response.wait().expect_err("sending on closed channel");
+        response.expect_err("sending on closed channel");
     }
 
     #[test]
@@ -865,7 +865,7 @@ mod test {
         drop(client);
 
         let response = client_proxy.call(TestServerMessage::TestRequest);
-        response.wait().expect_err("sending on a closed channel");
+        response.expect_err("sending on a closed channel");
     }
 
     #[test]

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -71,8 +71,7 @@ fn promote_thread(rpc: &rpccore::Proxy<ServerMessage, ClientMessage>) {
     match get_current_thread_info() {
         Ok(info) => {
             let bytes = info.serialize();
-            // Don't wait for the response, this is on the callback thread, which must not block.
-            rpc.call(ServerMessage::PromoteThreadToRealTime(bytes));
+            let _ = rpc.call(ServerMessage::PromoteThreadToRealTime(bytes));
         }
         Err(_) => {
             warn!("Could not remotely promote thread to RT.");

--- a/client/src/send_recv.rs
+++ b/client/src/send_recv.rs
@@ -43,7 +43,7 @@ macro_rules! send_recv {
         $rpc.call(ServerMessage::$smsg($($a),*))
     });
     (__recv $resp:expr, $rmsg:ident) => ({
-        match $resp.wait() {
+        match $resp {
             Ok(ClientMessage::$rmsg) => Ok(()),
             Ok(ClientMessage::Error(e)) => Err($crate::send_recv::_err(e)),
             Ok(m) => {
@@ -57,7 +57,7 @@ macro_rules! send_recv {
         }
     });
     (__recv $resp:expr, $rmsg:ident __result) => ({
-        match $resp.wait() {
+        match $resp {
             Ok(ClientMessage::$rmsg(v)) => Ok(v),
             Ok(ClientMessage::Error(e)) => Err($crate::send_recv::_err(e)),
             Ok(m) => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -252,14 +252,11 @@ impl ServerStreamCallbacks {
             return cubeb::ffi::CUBEB_ERROR.try_into().unwrap();
         }
 
-        let r = self
-            .data_callback_rpc
-            .call(CallbackReq::Data {
-                nframes,
-                input_frame_size: self.input_frame_size as usize,
-                output_frame_size: self.output_frame_size as usize,
-            })
-            .wait();
+        let r = self.data_callback_rpc.call(CallbackReq::Data {
+            nframes,
+            input_frame_size: self.input_frame_size as usize,
+            output_frame_size: self.output_frame_size as usize,
+        });
 
         match r {
             Ok(CallbackResp::Data(frames)) => {
@@ -282,8 +279,7 @@ impl ServerStreamCallbacks {
         trace!("Stream state callback: {:?}", state);
         let r = self
             .state_callback_rpc
-            .call(CallbackReq::State(state.into()))
-            .wait();
+            .call(CallbackReq::State(state.into()));
         match r {
             Ok(CallbackResp::State) => {}
             _ => {
@@ -296,8 +292,7 @@ impl ServerStreamCallbacks {
         trace!("Stream device change callback");
         let r = self
             .device_change_callback_rpc
-            .call(CallbackReq::DeviceChange)
-            .wait();
+            .call(CallbackReq::DeviceChange);
         match r {
             Ok(CallbackResp::DeviceChange) => {}
             _ => {
@@ -347,8 +342,7 @@ impl DeviceCollectionChangeCallback {
         );
         let _ = self
             .rpc
-            .call(DeviceCollectionReq::DeviceChange(device_type))
-            .wait();
+            .call(DeviceCollectionReq::DeviceChange(device_type));
     }
 }
 


### PR DESCRIPTION
Avoid several heap allocations by converting Proxy::call to blocking.  We cache a single channel on each Proxy rather than creating a new one per call.  crossbeam's bounded channels perform any required heap allocations when first initialized, further avoiding allocations on each channel send/recv with the std mpsc channel.