### PR TITLE
Improve Proxy<->ClientHandler disconnection handling.

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -66,7 +66,7 @@ impl EventLoopHandle {
         <C as Client>::ServerMessage: Serialize + Debug + AssociateHandleForMessage + Send,
         <C as Client>::ClientMessage: DeserializeOwned + Debug + AssociateHandleForMessage + Send,
     {
-        let (handler, mut proxy) = make_client::<C>();
+        let (handler, mut proxy) = make_client::<C>()?;
         let driver = Box::new(FramedDriver::new(handler));
         let r = self.add_connection(connection, driver);
         trace!("EventLoop::bind_client {:?}", r);
@@ -889,10 +889,9 @@ mod test {
         drop(server);
         drop(client);
 
-        let clone = client_proxy.clone();
-        clone
-            .call(TestServerMessage::TestRequest)
-            .expect_err("sending on a closed channel");
+        client_proxy
+            .try_clone()
+            .expect_err("cloning a closed proxy");
     }
 
     #[test]

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -883,6 +883,19 @@ mod test {
     }
 
     #[test]
+    fn clone_after_drop() {
+        init();
+        let (server, client, client_proxy) = setup();
+        drop(server);
+        drop(client);
+
+        let clone = client_proxy.clone();
+        clone
+            .call(TestServerMessage::TestRequest)
+            .expect_err("sending on a closed channel");
+    }
+
+    #[test]
     fn basic_event_loop_thread_callbacks() {
         init();
         let (start_tx, start_rx) = mpsc::channel();

--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -245,9 +245,7 @@ impl<C: Client> Handler for ClientHandler<C> {
         trace!("ClientHandler::consume");
         // `proxy` identifies the waiting Proxy expecting `response`.
         if let Some(proxy) = self.in_flight.pop_front() {
-            if let Err(e) = self.proxies.deliver(proxy, response) {
-                debug!("ClientHandler::consume - deliver error {:?}", e);
-            }
+            self.proxies.deliver(proxy, response)?;
         } else {
             return Err(Error::new(ErrorKind::Other, "request/response mismatch"));
         }

--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -4,9 +4,10 @@
 // accompanying file LICENSE for details
 
 use std::collections::VecDeque;
-use std::io::{self, Result};
+use std::io::{self, Error, ErrorKind, Result};
 use std::mem::ManuallyDrop;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crossbeam_channel::{self, Receiver, Sender};
 use mio::Token;
@@ -58,26 +59,25 @@ type ProxyRequest<Request> = (ProxyKey, Request);
 // Each Proxy is registered with the ClientHandler on initialization via the
 // ProxyManager and unregistered when dropped.
 // A ClientHandler normally lives until the last Proxy is dropped, but if the ClientHandler
-// encounters an internal error, `response_tx` will be closed and `proxy_mgr` can
-// no longer be upgraded to register new Proxies.
+// encounters an internal error, `handler_tx` and `response_tx` will be closed.
 #[derive(Debug)]
 pub struct Proxy<Request, Response> {
     handle: Option<(EventLoopHandle, Token)>,
-    key: ProxyKey,
+    key: Result<ProxyKey>,
     response_rx: Receiver<Response>,
     handler_tx: ManuallyDrop<Sender<ProxyRequest<Request>>>,
-    proxy_mgr: Weak<ProxyManager<Response>>,
+    proxy_mgr: Arc<ProxyManager<Response>>,
 }
 
 impl<Request, Response> Proxy<Request, Response> {
     fn new(
         handler_tx: Sender<ProxyRequest<Request>>,
-        proxy_mgr: Weak<ProxyManager<Response>>,
+        proxy_mgr: Arc<ProxyManager<Response>>,
     ) -> Self {
         let (tx, rx) = crossbeam_channel::bounded(1);
         Self {
             handle: None,
-            key: proxy_mgr.upgrade().unwrap().register_proxy(tx),
+            key: proxy_mgr.register_proxy(tx),
             response_rx: rx,
             handler_tx: ManuallyDrop::new(handler_tx),
             proxy_mgr,
@@ -85,21 +85,18 @@ impl<Request, Response> Proxy<Request, Response> {
     }
 
     pub fn call(&self, request: Request) -> Result<Response> {
-        match self.handler_tx.send((self.key, request)) {
-            Ok(_) => self.wake_connection(),
-            Err(_) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "proxy send error",
-                ))
+        match &self.key {
+            Ok(key) => {
+                match self.handler_tx.send((*key, request)) {
+                    Ok(_) => self.wake_connection(),
+                    Err(_) => return Err(Error::new(ErrorKind::Other, "proxy send error")),
+                }
+                match self.response_rx.recv() {
+                    Ok(resp) => Ok(resp),
+                    Err(_) => Err(Error::new(ErrorKind::Other, "proxy recv error")),
+                }
             }
-        }
-        match self.response_rx.recv() {
-            Ok(resp) => Ok(resp),
-            Err(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "proxy recv error",
-            )),
+            Err(_) => Err(Error::new(ErrorKind::Other, "proxy not registered")),
         }
     }
 
@@ -118,24 +115,23 @@ impl<Request, Response> Proxy<Request, Response> {
 
 impl<Request, Response> Clone for Proxy<Request, Response> {
     fn clone(&self) -> Self {
-        let (tx, rx) = crossbeam_channel::bounded(1);
-        Self {
-            handle: self.handle.clone(),
-            key: self.proxy_mgr.upgrade().unwrap().register_proxy(tx),
-            response_rx: rx,
-            handler_tx: self.handler_tx.clone(),
-            proxy_mgr: self.proxy_mgr.clone(),
-        }
+        let mut clone = Self::new((*self.handler_tx).clone(), self.proxy_mgr.clone());
+        let (handle, token) = self
+            .handle
+            .as_ref()
+            .expect("proxy not connected to event loop");
+        clone.connect_event_loop(handle.clone(), *token);
+        clone
     }
 }
 
 impl<Request, Response> Drop for Proxy<Request, Response> {
     fn drop(&mut self) {
         trace!("Proxy drop, waking EventLoop");
-        if let Some(mgr) = self.proxy_mgr.upgrade() {
-            mgr.unregister_proxy(self.key)
+        if let Ok(key) = self.key {
+            let _ = self.proxy_mgr.unregister_proxy(key);
         }
-        // Must drop Sender before waking the connection, otherwise
+        // Must drop `handler_tx` before waking the connection, otherwise
         // the wake may be processed before Sender is closed.
         unsafe {
             ManuallyDrop::drop(&mut self.handler_tx);
@@ -153,32 +149,64 @@ const RPC_CLIENT_INITIAL_PROXIES: usize = 32; // Initial proxy pre-allocation pe
 #[derive(Debug)]
 struct ProxyManager<Response> {
     proxies: Mutex<Slab<Sender<Response>>>,
+    connected: AtomicBool,
 }
 
 impl<Response> ProxyManager<Response> {
     fn new() -> Self {
         Self {
             proxies: Mutex::new(Slab::with_capacity(RPC_CLIENT_INITIAL_PROXIES)),
+            connected: AtomicBool::new(true),
         }
     }
 
     // Register a Proxy's response Sender, returning a unique ID identifying
     // the Proxy to the ClientHandler.
-    fn register_proxy(&self, tx: Sender<Response>) -> ProxyKey {
+    fn register_proxy(&self, tx: Sender<Response>) -> Result<ProxyKey> {
+        if !self.connected.load(Ordering::SeqCst) {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "register: proxy manager disconnected",
+            ));
+        }
         let mut proxies = self.proxies.lock().unwrap();
         let entry = proxies.vacant_entry();
         let key = entry.key();
         entry.insert(tx);
-        key
+        Ok(key)
     }
 
-    fn unregister_proxy(&self, key: ProxyKey) {
-        let _ = self.proxies.lock().unwrap().remove(key);
+    fn unregister_proxy(&self, key: ProxyKey) -> Result<()> {
+        if !self.connected.load(Ordering::SeqCst) {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "unregister: proxy manager disconnected",
+            ));
+        }
+        match self.proxies.lock().unwrap().try_remove(key) {
+            Some(_) => Ok(()),
+            None => Err(Error::new(
+                ErrorKind::Other,
+                "unregister: unknown proxy key",
+            )),
+        }
     }
 
     // Deliver ClientHandler's Response to the Proxy associated with `key`.
-    fn deliver(&self, key: ProxyKey, resp: Response) {
-        let _ = self.proxies.lock().unwrap()[key].send(resp);
+    fn deliver(&self, key: ProxyKey, resp: Response) -> Result<()> {
+        match self.proxies.lock().unwrap().get(key) {
+            Some(proxy) => {
+                drop(proxy.send(resp));
+                Ok(())
+            }
+            None => Err(Error::new(ErrorKind::Other, "deliver: unknown proxy key")),
+        }
+    }
+
+    // ClientHandler disconnected, close Proxy Senders to unblock any waiters.
+    fn disconnect_handler(&self) {
+        self.connected.store(false, Ordering::SeqCst);
+        self.proxies.lock().unwrap().clear();
     }
 }
 
@@ -191,9 +219,9 @@ impl<Response> ProxyManager<Response> {
 // connected to a ProxyResponse.
 pub(crate) struct ClientHandler<C: Client> {
     messages: Receiver<ProxyRequest<C::ServerMessage>>,
-    // Proxies hold a Weak<ProxyManager> to register on initialization.
+    // Proxies hold an Arc<ProxyManager> to register on initialization.
     // When ClientHandler drops, any Proxies blocked on a response will
-    // error due to the Sender closing.
+    // error due to their Sender closing.
     proxies: Arc<ProxyManager<C::ClientMessage>>,
     in_flight: VecDeque<ProxyKey>,
 }
@@ -207,8 +235,8 @@ impl<C: Client> ClientHandler<C> {
         }
     }
 
-    fn proxy_manager(&self) -> Weak<ProxyManager<<C as Client>::ClientMessage>> {
-        Arc::downgrade(&self.proxies)
+    fn proxy_manager(&self) -> &Arc<ProxyManager<<C as Client>::ClientMessage>> {
+        &self.proxies
     }
 }
 
@@ -220,12 +248,11 @@ impl<C: Client> Handler for ClientHandler<C> {
         trace!("ClientHandler::consume");
         // `proxy` identifies the waiting Proxy expecting `response`.
         if let Some(proxy) = self.in_flight.pop_front() {
-            self.proxies.deliver(proxy, response);
+            if let Err(e) = self.proxies.deliver(proxy, response) {
+                trace!("ClientHandler::consume - deliver error {:?}", e);
+            }
         } else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "request/response mismatch",
-            ));
+            return Err(Error::new(ErrorKind::Other, "request/response mismatch"));
         }
 
         Ok(())
@@ -253,12 +280,18 @@ impl<C: Client> Handler for ClientHandler<C> {
     }
 }
 
+impl<C: Client> Drop for ClientHandler<C> {
+    fn drop(&mut self) {
+        self.proxies.disconnect_handler();
+    }
+}
+
 pub(crate) fn make_client<C: Client>(
 ) -> (ClientHandler<C>, Proxy<C::ServerMessage, C::ClientMessage>) {
     let (tx, rx) = crossbeam_channel::bounded(RPC_CLIENT_INITIAL_PROXIES);
 
     let handler = ClientHandler::new(rx);
-    let proxy_mgr = handler.proxy_manager();
+    let proxy_mgr = handler.proxy_manager().clone();
 
     (handler, Proxy::new(tx, proxy_mgr))
 }

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -145,7 +145,7 @@ impl<'ctx> ClientStream<'ctx> {
     ) -> Result<Stream> {
         assert_not_in_callback();
 
-        let rpc = ctx.rpc();
+        let rpc = ctx.rpc()?;
         let create_params = StreamCreateParams {
             input_stream_params: init_params.input_stream_params,
             output_stream_params: init_params.output_stream_params,
@@ -227,8 +227,10 @@ impl<'ctx> ClientStream<'ctx> {
 impl Drop for ClientStream<'_> {
     fn drop(&mut self) {
         debug!("ClientStream drop");
-        let rpc = self.context.rpc();
-        let _ = send_recv!(rpc, StreamDestroy(self.token) => StreamDestroyed);
+        let _ = self
+            .context
+            .rpc()
+            .and_then(|rpc| send_recv!(rpc, StreamDestroy(self.token) => StreamDestroyed));
         debug!("ClientStream drop - stream destroyed");
         // Wait for CallbackServer to shutdown.  The remote server drops the RPC
         // connection during StreamDestroy, which will cause CallbackServer to drop
@@ -243,49 +245,49 @@ impl Drop for ClientStream<'_> {
 impl StreamOps for ClientStream<'_> {
     fn start(&mut self) -> Result<()> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamStart(self.token) => StreamStarted)
     }
 
     fn stop(&mut self) -> Result<()> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamStop(self.token) => StreamStopped)
     }
 
     fn position(&mut self) -> Result<u64> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamGetPosition(self.token) => StreamPosition())
     }
 
     fn latency(&mut self) -> Result<u32> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamGetLatency(self.token) => StreamLatency())
     }
 
     fn input_latency(&mut self) -> Result<u32> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamGetInputLatency(self.token) => StreamInputLatency())
     }
 
     fn set_volume(&mut self, volume: f32) -> Result<()> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamSetVolume(self.token, volume) => StreamVolumeSet)
     }
 
     fn set_name(&mut self, name: &CStr) -> Result<()> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         send_recv!(rpc, StreamSetName(self.token, name.to_owned()) => StreamNameSet)
     }
 
     fn current_device(&mut self) -> Result<&DeviceRef> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         match send_recv!(rpc, StreamGetCurrentDevice(self.token) => StreamCurrentDevice()) {
             Ok(d) => Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(Box::new(d.into()))) }),
             Err(e) => Err(e),
@@ -309,7 +311,7 @@ impl StreamOps for ClientStream<'_> {
         device_changed_callback: ffi::cubeb_device_changed_callback,
     ) -> Result<()> {
         assert_not_in_callback();
-        let rpc = self.context.rpc();
+        let rpc = self.context.rpc()?;
         let enable = device_changed_callback.is_some();
         *self.device_change_cb.lock().unwrap() = device_changed_callback;
         send_recv!(rpc, StreamRegisterDeviceChangeCallback(self.token, enable) => StreamRegisterDeviceChangeCallback)

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -722,8 +722,8 @@ impl CubebServer {
             input_frame_size,
             output_frame_size,
             shm,
-            state_callback_rpc: rpc.clone(),
-            device_change_callback_rpc: rpc.clone(),
+            state_callback_rpc: rpc.try_clone()?,
+            device_change_callback_rpc: rpc.try_clone()?,
             data_callback_rpc: rpc,
         });
 


### PR DESCRIPTION
Make rpccore::Proxy's ProxyManager reference Arc instead of Weak, use a flag on the ProxyManager to signal disconnection between the ClientHandler and any Proxies.

Also add test for cloning RPC Proxy after the ClientHandler has dropped.

This is intended to address [BMO 1788544](https://bugzilla.mozilla.org/show_bug.cgi?id=1788544).