### PR TITLE
server: Unregister input and output device collection change callbacks separately

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -236,7 +236,7 @@ impl EventLoop {
                         debug!("{}: {:?}: done, removing", self.name, token);
                         let mut connection = self.connections.remove(token.0);
                         if let Err(e) = connection.shutdown(self.poll.registry()) {
-                            warn!(
+                            debug!(
                                 "{}: EventLoop drop - closing connection for {:?} failed: {:?}",
                                 self.name, token, e
                             );
@@ -286,7 +286,7 @@ impl EventLoop {
                         debug!("{}: {:?}: done (wake), removing", self.name, token);
                         let mut connection = self.connections.remove(token.0);
                         if let Err(e) = connection.shutdown(self.poll.registry()) {
-                            warn!(
+                            debug!(
                                 "{}: EventLoop drop - closing connection for {:?} failed: {:?}",
                                 self.name, token, e
                             );
@@ -309,7 +309,7 @@ impl Drop for EventLoop {
                 self.name, token
             );
             if let Err(e) = connection.shutdown(self.poll.registry()) {
-                warn!(
+                debug!(
                     "{}: EventLoop drop - closing connection for {:?} failed: {:?}",
                     self.name, token, e
                 );

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -367,13 +367,15 @@ impl Drop for CubebServer {
                     context: Ok(context),
                 }) = state.as_mut()
                 {
-                    let r = manager.unregister(
-                        context,
-                        device_collection_change_callbacks,
-                        cubeb::DeviceType::all(),
-                    );
-                    if r.is_err() {
-                        debug!("CubebServer: unregister failed: {:?}", r);
+                    for devtype in [cubeb::DeviceType::INPUT, cubeb::DeviceType::OUTPUT] {
+                        let r = manager.unregister(
+                            context,
+                            device_collection_change_callbacks,
+                            devtype,
+                        );
+                        if r.is_err() {
+                            debug!("CubebServer: unregister failed: {:?}", r);
+                        }
                     }
                 }
             })


### PR DESCRIPTION
Since CubebDeviceCollectionManager tracks each callback registration independently, trying to unregister for "all" when CubebServer drops would fail to match and made CubebServer's drop handling effectively a no-op.

Also downgrade some EventLoop warnings to debug messages.