### PR TITLE
Switch to `Completion` and thread-safe queue instead of using channels.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -21,7 +21,7 @@ serde_bytes = "0.11"
 mio = { version = "0.8",  features = ["os-poll", "net", "os-ext"] }
 slab = "0.4"
 scopeguard = "1.1.0"
-crossbeam-channel = "0.5"
+crossbeam-queue = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -4,10 +4,10 @@
 // accompanying file LICENSE for details
 
 use std::io::{self, Result};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, Weak};
 use std::thread;
 
-use crossbeam_channel::{self, Receiver, Sender};
+use crossbeam_queue::ArrayQueue;
 use mio::{event::Event, Events, Interest, Poll, Registry, Token, Waker};
 use slab::Slab;
 
@@ -54,7 +54,7 @@ enum Request {
 #[derive(Clone, Debug)]
 pub struct EventLoopHandle {
     waker: Arc<Waker>,
-    requests_tx: Sender<Request>,
+    requests: Weak<ArrayQueue<Request>>,
 }
 
 impl EventLoopHandle {
@@ -100,13 +100,23 @@ impl EventLoopHandle {
         driver: Box<dyn Driver + Send>,
     ) -> Result<Token> {
         assert_not_in_event_loop_thread();
+        let requests = if let Some(req) = self.requests.upgrade() {
+            req
+        } else {
+            debug!(
+                "EventLoopHandle[{:p}]: add_connection failed - EventLoop dropped",
+                self
+            );
+            return Err(io::ErrorKind::ConnectionAborted.into());
+        };
         let (tx, rx) = mpsc::channel();
-        self.requests_tx
-            .send(Request::AddConnection(connection, driver, tx))
+        requests
+            .push(Request::AddConnection(connection, driver, tx))
             .map_err(|_| {
                 debug!("EventLoopHandle::add_connection send failed");
                 io::ErrorKind::ConnectionAborted
-            })?;
+            })
+            .expect("TODO: handle error");
         self.waker.wake()?;
         rx.recv().map_err(|_| {
             debug!("EventLoopHandle::add_connection recv failed");
@@ -116,19 +126,44 @@ impl EventLoopHandle {
 
     // Signal EventLoop to shutdown.  Causes EventLoop::poll to return Ok(false).
     fn shutdown(&self) -> Result<()> {
-        self.requests_tx.send(Request::Shutdown).map_err(|_| {
-            debug!("EventLoopHandle::shutdown send failed");
-            io::ErrorKind::ConnectionAborted
-        })?;
+        let requests = if let Some(req) = self.requests.upgrade() {
+            req
+        } else {
+            debug!(
+                "EventLoopHandle[{:p}]: shutdown failed - EventLoop dropped",
+                self
+            );
+            return Err(io::ErrorKind::ConnectionAborted.into());
+        };
+        requests
+            .push(Request::Shutdown)
+            .map_err(|_| {
+                debug!("EventLoopHandle::shutdown send failed");
+                io::ErrorKind::ConnectionAborted
+            })
+            .expect("TODO: handle error");
         self.waker.wake()
     }
 
     // Signal EventLoop to wake connection specified by `token` for processing.
     pub(crate) fn wake_connection(&self, token: Token) {
-        match self.requests_tx.send(Request::WakeConnection(token)) {
-            Ok(_) => self.waker.wake().expect("wake failed"),
-            Err(e) => debug!("EventLoopHandle::wake_connection failed: {:?}", e),
-        }
+        let requests = if let Some(req) = self.requests.upgrade() {
+            req
+        } else {
+            debug!(
+                "EventLoopHandle[{:p}]: wake_connection failed - EventLoop dropped",
+                self
+            );
+            return;
+        };
+        requests
+            .push(Request::WakeConnection(token))
+            .map_err(|_| {
+                debug!("EventLoopHandle::wake_connection failed");
+                io::ErrorKind::ConnectionAborted
+            })
+            .expect("TODO: handle error");
+        self.waker.wake().expect("wake failed");
     }
 }
 
@@ -141,8 +176,7 @@ struct EventLoop {
     waker: Arc<Waker>,
     name: String,
     connections: Slab<Connection>,
-    requests_rx: Receiver<Request>,
-    requests_tx: Sender<Request>,
+    requests: Arc<ArrayQueue<Request>>,
 }
 
 const EVENT_LOOP_INITIAL_CLIENTS: usize = 64; // Initial client allocation, exceeding this will cause the connection slab to grow.
@@ -152,15 +186,13 @@ impl EventLoop {
     fn new(name: String) -> Result<EventLoop> {
         let poll = Poll::new()?;
         let waker = Arc::new(Waker::new(poll.registry(), WAKE_TOKEN)?);
-        let (tx, rx) = crossbeam_channel::bounded(EVENT_LOOP_INITIAL_CLIENTS);
         let eventloop = EventLoop {
             poll,
             events: Events::with_capacity(EVENT_LOOP_EVENTS_PER_ITERATION),
             waker,
             name,
             connections: Slab::with_capacity(EVENT_LOOP_INITIAL_CLIENTS),
-            requests_rx: rx,
-            requests_tx: tx,
+            requests: Arc::new(ArrayQueue::new(EVENT_LOOP_INITIAL_CLIENTS)),
         };
 
         Ok(eventloop)
@@ -170,7 +202,7 @@ impl EventLoop {
     fn handle(&mut self) -> EventLoopHandle {
         EventLoopHandle {
             waker: self.waker.clone(),
-            requests_tx: self.requests_tx.clone(),
+            requests: Arc::downgrade(&self.requests),
         }
     }
 
@@ -247,7 +279,7 @@ impl EventLoop {
         }
 
         // If the waker was signalled there may be pending requests to process.
-        while let Ok(req) = self.requests_rx.try_recv() {
+        while let Some(req) = self.requests.pop() {
             match req {
                 Request::AddConnection(pipe, driver, tx) => {
                     debug!("{}: EventLoop: handling add_connection", self.name);
@@ -889,9 +921,9 @@ mod test {
         drop(server);
         drop(client);
 
-        client_proxy
-            .try_clone()
-            .expect_err("cloning a closed proxy");
+        let clone = client_proxy.clone();
+        let response = clone.call(TestServerMessage::TestRequest);
+        response.expect_err("sending to a dropped ClientHandler");
     }
 
     #[test]

--- a/audioipc/src/rpccore.rs
+++ b/audioipc/src/rpccore.rs
@@ -3,16 +3,108 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details
 
+use crossbeam_queue::ArrayQueue;
+use mio::Token;
+use std::cell::UnsafeCell;
 use std::collections::VecDeque;
 use std::io::{self, Error, ErrorKind, Result};
+use std::marker::PhantomPinned;
 use std::mem::ManuallyDrop;
-use std::sync::{Arc, Mutex};
-
-use crossbeam_channel::{self, Receiver, Sender};
-use mio::Token;
-use slab::Slab;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
 
 use crate::ipccore::EventLoopHandle;
+
+// This provides a safe-ish method for a thread to allocate
+// stack storage space for a result, then pass a (wrapped)
+// pointer to that location to another thread via
+// a CompletionWriter to eventually store a result into.
+struct Completion<T> {
+    item: UnsafeCell<Option<T>>,
+    writer: AtomicBool,
+    _pin: PhantomPinned, // disable rustc's no-alias
+}
+
+impl<T> Completion<T> {
+    fn new() -> Self {
+        Completion {
+            item: UnsafeCell::new(None),
+            writer: AtomicBool::new(false),
+            _pin: PhantomPinned,
+        }
+    }
+
+    // Wait until the writer completes, then return the result.
+    // This is intended to be a single-use function, once the writer
+    // has completed any further attempts to wait will return None.
+    fn wait(&self) -> Option<T> {
+        // Wait for the writer to complete or be dropped.
+        while self.writer.load(Ordering::Acquire) {
+            std::thread::park();
+        }
+        unsafe { (*self.item.get()).take() }
+    }
+
+    // Create a writer for the other thread to store the
+    // expected result into.
+    fn writer(&self) -> CompletionWriter<T> {
+        assert!(!self.writer.load(Ordering::Relaxed));
+        self.writer.store(true, Ordering::Release);
+        CompletionWriter {
+            ptr: self as *const _ as *mut _,
+            waiter: std::thread::current(),
+        }
+    }
+}
+
+impl<T> Drop for Completion<T> {
+    fn drop(&mut self) {
+        // Wait for the outstanding writer to complete before
+        // dropping, since the CompletionWriter references
+        // memory owned by this object.
+        while self.writer.load(Ordering::Acquire) {
+            std::thread::park();
+        }
+    }
+}
+
+struct CompletionWriter<T> {
+    ptr: *mut Completion<T>, // Points to a Completion on another thread's stack
+    waiter: std::thread::Thread, // Identifies thread waiting for completion
+}
+
+impl<T> CompletionWriter<T> {
+    fn set(self, value: T) {
+        // Store the result into the Completion's memory.
+        // Since `set` consumes `self`, rely on `Drop` to
+        // mark the writer as done and wake the Completion's
+        // thread.
+        unsafe {
+            assert!((*self.ptr).writer.load(Ordering::Relaxed));
+            *(*self.ptr).item.get() = Some(value);
+        }
+    }
+}
+
+impl<T> Drop for CompletionWriter<T> {
+    fn drop(&mut self) {
+        // Mark writer as complete - if `set` was not called,
+        // the waiter will receive `None`.
+        unsafe {
+            (*self.ptr).writer.store(false, Ordering::Release);
+        }
+        // Wake the Completion's thread.
+        self.waiter.unpark();
+    }
+}
+
+// Safety: CompletionWriter holds a pointer to a Completion
+// residing on another thread's stack.  The Completion always
+// waits for an outstanding writer if present, and CompletionWriter
+// releases the waiter and wakes the Completion's thread on drop,
+// so this pointer will always be live for the duration of a
+// CompletionWriter.
+unsafe impl<T> Send for CompletionWriter<T> {}
 
 // RPC message handler.  Implemented by ClientHandler (for Client)
 // and ServerHandler (for Server).
@@ -45,62 +137,46 @@ pub trait Server {
 }
 
 // RPC Client Proxy implementation.
-type ProxyKey = usize;
-type ProxyRequest<Request> = (ProxyKey, Request);
+type ProxyRequest<Request, Response> = (Request, CompletionWriter<Response>);
 
 // RPC Proxy that may be `clone`d for use by multiple owners/threads.
 // A Proxy `call` arranges for the supplied request to be transmitted
 // to the associated Server via RPC and blocks awaiting the response
-// via `response_rx`.
-// A Proxy is associated with the ClientHandler via `handler_tx` to send requests,
-// `response_rx` to receive responses, and uses `key` to identify the Proxy with
-// the sending side of `response_rx`  ClientHandler.
-// Each Proxy is registered with the ClientHandler on initialization via the
-// ProxyManager and unregistered when dropped.
+// via the associated `Completion`.
 // A ClientHandler normally lives until the last Proxy is dropped, but if the ClientHandler
-// encounters an internal error, `handler_tx` and `response_tx` will be closed.
+// encounters an internal error, `requests` will fail to upgrade, allowing
+// the proxy to report an error.
 #[derive(Debug)]
 pub struct Proxy<Request, Response> {
     handle: Option<(EventLoopHandle, Token)>,
-    key: ProxyKey,
-    response_rx: Receiver<Response>,
-    handler_tx: ManuallyDrop<Sender<ProxyRequest<Request>>>,
-    proxy_mgr: Arc<ProxyManager<Response>>,
+    requests: ManuallyDrop<Weak<ArrayQueue<ProxyRequest<Request, Response>>>>,
 }
 
 impl<Request, Response> Proxy<Request, Response> {
-    fn new(
-        handler_tx: Sender<ProxyRequest<Request>>,
-        proxy_mgr: Arc<ProxyManager<Response>>,
-    ) -> Result<Self> {
-        let (tx, rx) = crossbeam_channel::bounded(1);
-        Ok(Self {
+    fn new(requests: Weak<ArrayQueue<ProxyRequest<Request, Response>>>) -> Self {
+        Self {
             handle: None,
-            key: proxy_mgr.register_proxy(tx)?,
-            response_rx: rx,
-            handler_tx: ManuallyDrop::new(handler_tx),
-            proxy_mgr,
-        })
-    }
-
-    pub fn try_clone(&self) -> Result<Self> {
-        let mut clone = Self::new((*self.handler_tx).clone(), self.proxy_mgr.clone())?;
-        let (handle, token) = self
-            .handle
-            .as_ref()
-            .expect("proxy not connected to event loop");
-        clone.connect_event_loop(handle.clone(), *token);
-        Ok(clone)
+            requests: ManuallyDrop::new(requests),
+        }
     }
 
     pub fn call(&self, request: Request) -> Result<Response> {
-        match self.handler_tx.send((self.key, request)) {
-            Ok(_) => self.wake_connection(),
-            Err(_) => return Err(Error::new(ErrorKind::Other, "proxy send error")),
+        let req = if let Some(req) = self.requests.upgrade() {
+            req
+        } else {
+            debug!("Proxy[{:p}]: call failed - CH::requests dropped", self);
+            return Err(Error::new(ErrorKind::Other, "proxy send error"));
+        };
+        let response = Completion::new();
+        let response_writer = response.writer();
+        if req.push((request, response_writer)).is_err() {
+            debug!("Proxy[{:p}]: call failed - CH::requests full", self);
+            return Err(Error::new(ErrorKind::Other, "proxy send error"));
         }
-        match self.response_rx.recv() {
-            Ok(resp) => Ok(resp),
-            Err(_) => Err(Error::new(ErrorKind::Other, "proxy recv error")),
+        self.wake_connection();
+        match response.wait() {
+            Some(resp) => Ok(resp),
+            None => Err(Error::new(ErrorKind::Other, "proxy recv error")),
         }
     }
 
@@ -117,95 +193,35 @@ impl<Request, Response> Proxy<Request, Response> {
     }
 }
 
+impl<Request, Response> Clone for Proxy<Request, Response> {
+    fn clone(&self) -> Self {
+        let mut clone = Self::new((*self.requests).clone());
+        let (handle, token) = self
+            .handle
+            .as_ref()
+            .expect("proxy not connected to event loop");
+        clone.connect_event_loop(handle.clone(), *token);
+        clone
+    }
+}
+
 impl<Request, Response> Drop for Proxy<Request, Response> {
     fn drop(&mut self) {
         trace!("Proxy drop, waking EventLoop");
-        let _ = self.proxy_mgr.unregister_proxy(self.key);
-        // Must drop `handler_tx` before waking the connection, otherwise
-        // the wake may be processed before Sender is closed.
+        // Must drop `requests` before waking the connection, otherwise
+        // the wake may be processed before the (last) weak reference is
+        // dropped.
+        let last_proxy = Weak::weak_count(&self.requests);
         unsafe {
-            ManuallyDrop::drop(&mut self.handler_tx);
+            ManuallyDrop::drop(&mut self.requests);
         }
-        if self.handle.is_some() {
+        if last_proxy == 1 && self.handle.is_some() {
             self.wake_connection()
         }
     }
 }
 
 const RPC_CLIENT_INITIAL_PROXIES: usize = 32; // Initial proxy pre-allocation per client.
-
-// Manage the Sender side of a ClientHandler's Proxies.  Each Proxy registers itself with
-// the manager on initialization.
-#[derive(Debug)]
-struct ProxyManager<Response> {
-    proxies: Mutex<Option<Slab<Sender<Response>>>>,
-}
-
-impl<Response> ProxyManager<Response> {
-    fn new() -> Self {
-        Self {
-            proxies: Mutex::new(Some(Slab::with_capacity(RPC_CLIENT_INITIAL_PROXIES))),
-        }
-    }
-
-    // Register a Proxy's response Sender, returning a unique ID identifying
-    // the Proxy to the ClientHandler.
-    fn register_proxy(&self, tx: Sender<Response>) -> Result<ProxyKey> {
-        let mut proxies = self.proxies.lock().unwrap();
-        match &mut *proxies {
-            Some(proxies) => {
-                let entry = proxies.vacant_entry();
-                let key = entry.key();
-                entry.insert(tx);
-                Ok(key)
-            }
-            None => Err(Error::new(
-                ErrorKind::Other,
-                "register: proxy manager disconnected",
-            )),
-        }
-    }
-
-    fn unregister_proxy(&self, key: ProxyKey) -> Result<()> {
-        let mut proxies = self.proxies.lock().unwrap();
-        match &mut *proxies {
-            Some(proxies) => match proxies.try_remove(key) {
-                Some(_) => Ok(()),
-                None => Err(Error::new(
-                    ErrorKind::Other,
-                    "unregister: unknown proxy key",
-                )),
-            },
-            None => Err(Error::new(
-                ErrorKind::Other,
-                "unregister: proxy manager disconnected",
-            )),
-        }
-    }
-
-    // Deliver ClientHandler's Response to the Proxy associated with `key`.
-    fn deliver(&self, key: ProxyKey, resp: Response) -> Result<()> {
-        let proxies = self.proxies.lock().unwrap();
-        match &*proxies {
-            Some(proxies) => match proxies.get(key) {
-                Some(proxy) => {
-                    drop(proxy.send(resp));
-                    Ok(())
-                }
-                None => Err(Error::new(ErrorKind::Other, "deliver: unknown proxy key")),
-            },
-            None => Err(Error::new(
-                ErrorKind::Other,
-                "unregister: proxy manager disconnected",
-            )),
-        }
-    }
-
-    // ClientHandler disconnected, close Proxy Senders to unblock any waiters.
-    fn disconnect_handler(&self) {
-        *self.proxies.lock().unwrap() = None;
-    }
-}
 
 // Client-specific Handler implementation.
 // The IPC EventLoop Driver calls this to execute client-specific
@@ -215,25 +231,18 @@ impl<Response> ProxyManager<Response> {
 // trigger response completion by sending the response via a channel
 // connected to a ProxyResponse.
 pub(crate) struct ClientHandler<C: Client> {
-    messages: Receiver<ProxyRequest<C::ServerMessage>>,
-    // Proxies hold an Arc<ProxyManager> to register on initialization.
-    // When ClientHandler drops, any Proxies blocked on a response will
-    // error due to their Sender closing.
-    proxies: Arc<ProxyManager<C::ClientMessage>>,
-    in_flight: VecDeque<ProxyKey>,
+    in_flight: VecDeque<CompletionWriter<C::ClientMessage>>,
+    requests: Arc<ArrayQueue<ProxyRequest<C::ServerMessage, C::ClientMessage>>>,
 }
 
 impl<C: Client> ClientHandler<C> {
-    fn new(rx: Receiver<ProxyRequest<C::ServerMessage>>) -> ClientHandler<C> {
+    fn new(
+        requests: Arc<ArrayQueue<ProxyRequest<C::ServerMessage, C::ClientMessage>>>,
+    ) -> ClientHandler<C> {
         ClientHandler::<C> {
-            messages: rx,
-            proxies: Arc::new(ProxyManager::new()),
             in_flight: VecDeque::with_capacity(RPC_CLIENT_INITIAL_PROXIES),
+            requests,
         }
-    }
-
-    fn proxy_manager(&self) -> &Arc<ProxyManager<<C as Client>::ClientMessage>> {
-        &self.proxies
     }
 }
 
@@ -243,9 +252,8 @@ impl<C: Client> Handler for ClientHandler<C> {
 
     fn consume(&mut self, response: Self::In) -> Result<()> {
         trace!("ClientHandler::consume");
-        // `proxy` identifies the waiting Proxy expecting `response`.
-        if let Some(proxy) = self.in_flight.pop_front() {
-            self.proxies.deliver(proxy, response)?;
+        if let Some(response_writer) = self.in_flight.pop_front() {
+            response_writer.set(response);
         } else {
             return Err(Error::new(ErrorKind::Other, "request/response mismatch"));
         }
@@ -256,40 +264,35 @@ impl<C: Client> Handler for ClientHandler<C> {
     fn produce(&mut self) -> Result<Option<Self::Out>> {
         trace!("ClientHandler::produce");
 
+        // If the weak count is zero, no proxies are attached and
+        // no further proxies can be attached since every proxy
+        // after the initial one is cloned from an existing instance.
+        if Arc::weak_count(&self.requests) == 0 {
+            return Err(io::ErrorKind::ConnectionAborted.into());
+        }
         // Try to get a new message
-        match self.messages.try_recv() {
-            Ok((proxy, request)) => {
+        match self.requests.pop() {
+            Some((request, response_writer)) => {
                 trace!("  --> received request");
-                self.in_flight.push_back(proxy);
+                self.in_flight.push_back(response_writer);
                 Ok(Some(request))
             }
-            Err(crossbeam_channel::TryRecvError::Empty) => {
+            None => {
                 trace!("  --> no request");
                 Ok(None)
             }
-            Err(e) => {
-                trace!("  --> client disconnected");
-                Err(io::Error::new(io::ErrorKind::ConnectionAborted, e))
-            }
         }
-    }
-}
-
-impl<C: Client> Drop for ClientHandler<C> {
-    fn drop(&mut self) {
-        self.proxies.disconnect_handler();
     }
 }
 
 #[allow(clippy::type_complexity)]
 pub(crate) fn make_client<C: Client>(
 ) -> Result<(ClientHandler<C>, Proxy<C::ServerMessage, C::ClientMessage>)> {
-    let (tx, rx) = crossbeam_channel::bounded(RPC_CLIENT_INITIAL_PROXIES);
+    let requests = Arc::new(ArrayQueue::new(RPC_CLIENT_INITIAL_PROXIES));
+    let proxy_req = Arc::downgrade(&requests);
+    let handler = ClientHandler::new(requests);
 
-    let handler = ClientHandler::new(rx);
-    let proxy_mgr = handler.proxy_manager().clone();
-
-    Ok((handler, Proxy::new(tx, proxy_mgr)?))
+    Ok((handler, Proxy::new(proxy_req)))
 }
 
 // Server-specific Handler implementation.

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -56,8 +56,8 @@ impl ClientContext {
     }
 
     #[doc(hidden)]
-    pub fn rpc(&self) -> Result<rpccore::Proxy<ServerMessage, ClientMessage>> {
-        self.rpc.try_clone().map_err(|_| Error::default())
+    pub fn rpc(&self) -> rpccore::Proxy<ServerMessage, ClientMessage> {
+        self.rpc.clone()
     }
 
     #[doc(hidden)]
@@ -186,7 +186,7 @@ impl ContextOps for ClientContext {
             .handle()
             .bind_client::<CubebClient>(server_connection)
             .map_err(|_| Error::default())?;
-        let rpc2 = rpc.try_clone().map_err(|_| Error::default())?;
+        let rpc2 = rpc.clone();
 
         // Don't let errors bubble from here.  Later calls against this context
         // will return errors the caller expects to handle.
@@ -225,18 +225,18 @@ impl ContextOps for ClientContext {
 
     fn max_channel_count(&mut self) -> Result<u32> {
         assert_not_in_callback();
-        send_recv!(self.rpc()?, ContextGetMaxChannelCount => ContextMaxChannelCount())
+        send_recv!(self.rpc(), ContextGetMaxChannelCount => ContextMaxChannelCount())
     }
 
     fn min_latency(&mut self, params: StreamParams) -> Result<u32> {
         assert_not_in_callback();
         let params = messages::StreamParams::from(params.as_ref());
-        send_recv!(self.rpc()?, ContextGetMinLatency(params) => ContextMinLatency())
+        send_recv!(self.rpc(), ContextGetMinLatency(params) => ContextMinLatency())
     }
 
     fn preferred_sample_rate(&mut self) -> Result<u32> {
         assert_not_in_callback();
-        send_recv!(self.rpc()?, ContextGetPreferredSampleRate => ContextPreferredSampleRate())
+        send_recv!(self.rpc(), ContextGetPreferredSampleRate => ContextPreferredSampleRate())
     }
 
     fn enumerate_devices(
@@ -246,7 +246,7 @@ impl ContextOps for ClientContext {
     ) -> Result<()> {
         assert_not_in_callback();
         let v: Vec<ffi::cubeb_device_info> = send_recv!(
-            self.rpc()?, ContextGetDeviceEnumeration(devtype.bits()) => ContextEnumeratedDevices())?
+            self.rpc(), ContextGetDeviceEnumeration(devtype.bits()) => ContextEnumeratedDevices())?
         .into_iter()
         .map(|i| i.into())
         .collect();
@@ -329,7 +329,7 @@ impl ContextOps for ClientContext {
         assert_not_in_callback();
 
         if !self.device_collection_rpc {
-            let mut fd = send_recv!(self.rpc()?,
+            let mut fd = send_recv!(self.rpc(),
                                  ContextSetupDeviceCollectionCallback =>
                                  ContextSetupDeviceCollectionCallback())?;
 
@@ -358,7 +358,7 @@ impl ContextOps for ClientContext {
         }
 
         let enable = collection_changed_callback.is_some();
-        send_recv!(self.rpc()?,
+        send_recv!(self.rpc(),
                    ContextRegisterDeviceCollectionChanged(devtype.bits(), enable) =>
                    ContextRegisteredDeviceCollectionChanged)
     }
@@ -367,9 +367,7 @@ impl ContextOps for ClientContext {
 impl Drop for ClientContext {
     fn drop(&mut self) {
         debug!("ClientContext dropped...");
-        let _ = self
-            .rpc()
-            .and_then(|rpc| send_recv!(rpc, ClientDisconnect => ClientDisconnected));
+        let _ = send_recv!(self.rpc(), ClientDisconnect => ClientDisconnected);
     }
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -724,8 +724,8 @@ impl CubebServer {
             input_frame_size,
             output_frame_size,
             shm,
-            state_callback_rpc: rpc.try_clone()?,
-            device_change_callback_rpc: rpc.try_clone()?,
+            state_callback_rpc: rpc.clone(),
+            device_change_callback_rpc: rpc.clone(),
             data_callback_rpc: rpc,
         });
 


### PR DESCRIPTION
Rust/crossbeam channels turn out not to be ideal for RT-safe uses, since they may allocate and call `thread::yield_now()`.  Instead, use a `Completion` object allocated on the stack to wait for the response from the handler thread.