### PR TITLE
Use a larger default RLIMIT_RTTIME for now

### DIFF
--- a/audioipc/src/codec.rs
+++ b/audioipc/src/codec.rs
@@ -5,6 +5,11 @@
 
 //! `Encoder`s and `Decoder`s from items to/from `BytesMut` buffers.
 
+// The assert in LengthDelimitedCodec::decode triggers this clippy warning but
+// requires upgrading the workspace to Rust 2021 to resolve.
+// This should be fixed in Rust 1.68, after which the following `allow` can be deleted.
+#![allow(clippy::uninlined_format_args)]
+
 use bincode::{self, Options};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Buf, BufMut, BytesMut};

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -81,7 +81,7 @@ fn promote_thread(rpc: &rpccore::Proxy<ServerMessage, ClientMessage>) {
 
 #[cfg(not(target_os = "linux"))]
 fn promote_thread(_rpc: &rpccore::Proxy<ServerMessage, ClientMessage>) {
-    match promote_current_thread_to_real_time(256, 48000) {
+    match promote_current_thread_to_real_time(0, 48000) {
         Ok(_) => {
             info!("Audio thread promoted to real-time.");
         }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -98,7 +98,7 @@ fn init_threads(
         None,
         move || {
             trace!("Starting {} thread", callback_name);
-            if let Err(e) = promote_current_thread_to_real_time(256, 48000) {
+            if let Err(e) = promote_current_thread_to_real_time(0, 48000) {
                 debug!(
                     "Failed to promote {} thread to real-time: {:?}",
                     callback_name, e

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -647,7 +647,7 @@ impl CubebServer {
             #[cfg(target_os = "linux")]
             ServerMessage::PromoteThreadToRealTime(thread_info) => {
                 let info = RtPriorityThreadInfo::deserialize(thread_info);
-                match promote_thread_to_real_time(info, 256, 48000) {
+                match promote_thread_to_real_time(info, 0, 48000) {
                     Ok(_) => {
                         info!("Promotion of content process thread to real-time OK");
                     }


### PR DESCRIPTION
Matthew, this is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1814692#c10.

This is reverting back to the previous value (in the other branch). `256 / 48000` is quite small, it's about 5ms.

For real-time scenario (= `MediaTrackGraph`), we're using buffer sizes of 10ms on Windows, about 10ms on macOS (in WebRTC calls, it's smaller when just doing Web Audio), but often a lot larger on Linux desktop and Android.

So on Linux desktop, this means that we're only allowing a fraction of the possible real-time budget (which is plenty for normal playback, not so much for demanding Web Audio API scenarios, especially when using big buffers with PulseAudio, it's nicer when using pipewire).

Additionally, WebRTC uses `SCHED_FIFO` for desktop capture, and that's converting/copying multi-megabyte buffers, so 5ms is clearly too short, but we're also probably changing the scheduling policy there so that it's not real-time.