### PR TITLE
Refactor shared ArrayQueue logic into RequestQueue wrapper.

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -4,15 +4,16 @@
 // accompanying file LICENSE for details
 
 use std::io::{self, Result};
-use std::sync::{mpsc, Arc, Weak};
+use std::sync::{mpsc, Arc};
 use std::thread;
 
-use crossbeam_queue::ArrayQueue;
 use mio::{event::Event, Events, Interest, Poll, Registry, Token, Waker};
 use slab::Slab;
 
 use crate::messages::AssociateHandleForMessage;
-use crate::rpccore::{make_client, make_server, Client, Handler, Proxy, Server};
+use crate::rpccore::{
+    make_client, make_server, Client, Handler, Proxy, RequestQueue, RequestQueueSender, Server,
+};
 use crate::{
     codec::Codec,
     codec::LengthDelimitedCodec,
@@ -54,7 +55,7 @@ enum Request {
 #[derive(Clone, Debug)]
 pub struct EventLoopHandle {
     waker: Arc<Waker>,
-    requests: Weak<ArrayQueue<Request>>,
+    requests: RequestQueueSender<Request>,
 }
 
 impl EventLoopHandle {
@@ -100,23 +101,13 @@ impl EventLoopHandle {
         driver: Box<dyn Driver + Send>,
     ) -> Result<Token> {
         assert_not_in_event_loop_thread();
-        let requests = if let Some(req) = self.requests.upgrade() {
-            req
-        } else {
-            debug!(
-                "EventLoopHandle[{:p}]: add_connection failed - EventLoop dropped",
-                self
-            );
-            return Err(io::ErrorKind::ConnectionAborted.into());
-        };
         let (tx, rx) = mpsc::channel();
-        requests
+        self.requests
             .push(Request::AddConnection(connection, driver, tx))
             .map_err(|_| {
                 debug!("EventLoopHandle::add_connection send failed");
                 io::ErrorKind::ConnectionAborted
-            })
-            .expect("TODO: handle error");
+            })?;
         self.waker.wake()?;
         rx.recv().map_err(|_| {
             debug!("EventLoopHandle::add_connection recv failed");
@@ -126,44 +117,18 @@ impl EventLoopHandle {
 
     // Signal EventLoop to shutdown.  Causes EventLoop::poll to return Ok(false).
     fn shutdown(&self) -> Result<()> {
-        let requests = if let Some(req) = self.requests.upgrade() {
-            req
-        } else {
-            debug!(
-                "EventLoopHandle[{:p}]: shutdown failed - EventLoop dropped",
-                self
-            );
-            return Err(io::ErrorKind::ConnectionAborted.into());
-        };
-        requests
-            .push(Request::Shutdown)
-            .map_err(|_| {
-                debug!("EventLoopHandle::shutdown send failed");
-                io::ErrorKind::ConnectionAborted
-            })
-            .expect("TODO: handle error");
+        self.requests.push(Request::Shutdown).map_err(|_| {
+            debug!("EventLoopHandle::shutdown send failed");
+            io::ErrorKind::ConnectionAborted
+        })?;
         self.waker.wake()
     }
 
     // Signal EventLoop to wake connection specified by `token` for processing.
     pub(crate) fn wake_connection(&self, token: Token) {
-        let requests = if let Some(req) = self.requests.upgrade() {
-            req
-        } else {
-            debug!(
-                "EventLoopHandle[{:p}]: wake_connection failed - EventLoop dropped",
-                self
-            );
-            return;
-        };
-        requests
-            .push(Request::WakeConnection(token))
-            .map_err(|_| {
-                debug!("EventLoopHandle::wake_connection failed");
-                io::ErrorKind::ConnectionAborted
-            })
-            .expect("TODO: handle error");
-        self.waker.wake().expect("wake failed");
+        if self.requests.push(Request::WakeConnection(token)).is_ok() {
+            self.waker.wake().expect("wake failed");
+        }
     }
 }
 
@@ -176,7 +141,7 @@ struct EventLoop {
     waker: Arc<Waker>,
     name: String,
     connections: Slab<Connection>,
-    requests: Arc<ArrayQueue<Request>>,
+    requests: Arc<RequestQueue<Request>>,
 }
 
 const EVENT_LOOP_INITIAL_CLIENTS: usize = 64; // Initial client allocation, exceeding this will cause the connection slab to grow.
@@ -192,7 +157,7 @@ impl EventLoop {
             waker,
             name,
             connections: Slab::with_capacity(EVENT_LOOP_INITIAL_CLIENTS),
-            requests: Arc::new(ArrayQueue::new(EVENT_LOOP_INITIAL_CLIENTS)),
+            requests: Arc::new(RequestQueue::new(EVENT_LOOP_INITIAL_CLIENTS)),
         };
 
         Ok(eventloop)
@@ -202,7 +167,7 @@ impl EventLoop {
     fn handle(&mut self) -> EventLoopHandle {
         EventLoopHandle {
             waker: self.waker.clone(),
-            requests: Arc::downgrade(&self.requests),
+            requests: self.requests.new_sender(),
         }
     }
 


### PR DESCRIPTION
This centralises the handling of Weak->Arc upgrades when sending, and avoids a footgun where the sender could keep the RequestQueue alive while waiting for a request to complete.

The existing code made this exact mistake: upgrading Weak->Arc, sending a request, and then waiting on the response while the upgraded Arc remained in scope.  The sender must drop the Arc after queuing the request and before waiting on the response to avoid the situation where the request is successfully queued while the server is shutting down - resulting in the queued Requests never being dropped and the sender becoming deadlocked.