### PR TITLE
Remove unnecessary asserts

### DIFF
--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -262,10 +262,7 @@ impl EventLoop {
                     );
                     let done = if let Some(connection) = self.connections.get_mut(token.0) {
                         match connection.handle_wake(self.poll.registry()) {
-                            Ok(done) => {
-                                assert!(!done);
-                                false
-                            }
+                            Ok(done) => done,
                             Err(e) => {
                                 debug!("{}: {:?}: connection error: {:?}", self.name, token, e);
                                 true

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -462,8 +462,11 @@ impl Connection {
             let r = self.io.recv_msg(&mut self.inbound);
             match r {
                 Ok(0) => {
-                    trace!("{:?}: recv EOF", self.token);
-                    assert!(self.inbound.is_empty()); // Ensure no unprocessed messages queued.
+                    trace!(
+                        "{:?}: recv EOF unprocessed inbound={}",
+                        self.token,
+                        self.inbound.is_empty()
+                    );
                     return Ok(true);
                 }
                 Ok(n) => {
@@ -477,8 +480,12 @@ impl Connection {
                             }
                         }
                         Err(e) => {
-                            debug!("{:?}: process_inbound error: {:?}", self.token, e);
-                            assert!(self.inbound.is_empty()); // Ensure no unprocessed messages queued.
+                            debug!(
+                                "{:?}: process_inbound error: {:?} unprocessed inbound={}",
+                                self.token,
+                                e,
+                                self.inbound.is_empty()
+                            );
                             return Err(e);
                         }
                     }


### PR DESCRIPTION
In `EventLoop::poll`, remove the `!done` assert and just return the result of `handle_wake`.  `Connection::handle_wake` may return `Ok(true)` if sending fails due to the remote having disconnected, in which case we'll remove the connection during `done` handling later.

In `Connection::recv_inbound`, remove the two `self.inbound.is_empty()` asserts - since the connection is in error, it will be removed when `recv_inbound` returns `Ok(true)` or an error, so we don't care about (and couldn't react to) the contents of the inbound buffer.