### PR TITLE
Switch to windows-sys.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-12]
         rust: [stable]
         experimental: [false]
         include:
@@ -21,7 +21,7 @@ jobs:
           - os: windows-2019
             rust: nightly
             experimental: true
-          - os: macos-10.15
+          - os: macos-12
             rust: nightly
             experimental: true
 

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -3,8 +3,8 @@ name = "audioipc2"
 version = "0.5.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
-        "Dan Glastonbury <dan.glastonbury@gmail.com>"
-        ]
+        "Dan Glastonbury <dan.glastonbury@gmail.com>",
+]
 license = "ISC"
 description = "Remote Cubeb IPC"
 edition = "2018"
@@ -18,7 +18,7 @@ log = "0.4"
 serde = "1"
 serde_derive = "1"
 serde_bytes = "0.11"
-mio = { version = "0.8",  features = ["os-poll", "net", "os-ext"] }
+mio = { version = "0.8", features = ["os-poll", "net", "os-ext"] }
 slab = "0.4"
 scopeguard = "1.1.0"
 crossbeam-queue = "0.3"
@@ -34,7 +34,14 @@ version = "0.26.1"
 default-features = false
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["combaseapi", "handleapi", "memoryapi", "objbase"] }
+windows-sys = { version = "0.48", features = [
+        "Win32_Foundation",
+        "Win32_Security",
+        "Win32_Storage_FileSystem",
+        "Win32_System_Com",
+        "Win32_System_Memory",
+        "Win32_System_Threading",
+] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ashmem = "0.1.2"

--- a/audioipc/src/sys/unix/cmsg.rs
+++ b/audioipc/src/sys/unix/cmsg.rs
@@ -17,7 +17,7 @@ trait AsBytes {
 impl<'a, T: Sized> AsBytes for &'a [T] {
     fn as_bytes(&self) -> &[u8] {
         // TODO: This should account for the alignment of T
-        let byte_count = self.len() * mem::size_of::<T>();
+        let byte_count = std::mem::size_of_val(*self);
         unsafe { slice::from_raw_parts(self.as_ptr() as *const _, byte_count) }
     }
 }

--- a/audioipc/src/sys/windows/mod.rs
+++ b/audioipc/src/sys/windows/mod.rs
@@ -14,7 +14,7 @@ use std::io::Result;
 
 use bytes::{Buf, BufMut};
 use mio::windows::NamedPipe;
-use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
+use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 
 use crate::PlatformHandle;
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,18 +3,14 @@ name = "audioipc2-client"
 version = "0.5.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
-        "Dan Glastonbury <dan.glastonbury@gmail.com>"
-        ]
+        "Dan Glastonbury <dan.glastonbury@gmail.com>",
+]
 license = "ISC"
 description = "Cubeb Backend for talking to remote cubeb server."
 edition = "2018"
 
 [dependencies]
-audioipc = { package = "audioipc2", path="../audioipc" }
+audioipc = { package = "audioipc2", path = "../audioipc" }
 cubeb-backend = "0.10"
 log = "0.4"
-
-[dependencies.audio_thread_priority]
-version = "0.26.1"
-default-features = false
-features = ["winapi"]
+audio_thread_priority = "0.26"

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -264,11 +264,7 @@ impl ContextOps for ClientContext {
         assert_not_in_callback();
         unsafe {
             let coll = &mut *collection.as_ptr();
-            let mut devices = Vec::from_raw_parts(
-                coll.device as *mut ffi::cubeb_device_info,
-                coll.count,
-                coll.count,
-            );
+            let mut devices = Vec::from_raw_parts(coll.device, coll.count, coll.count);
             for dev in &mut devices {
                 if !dev.device_id.is_null() {
                     let _ = CString::from_raw(dev.device_id as *mut _);

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { package = "audioipc2", path = "../audioipc" }
-audioipc-client= { package = "audioipc2-client", path = "../client" }
+audioipc-client = { package = "audioipc2-client", path = "../client" }
 audioipc-server = { package = "audioipc2-server", path = "../server" }
 cubeb = "0.10.0"
 env_logger = "0.9"
@@ -18,4 +18,7 @@ log = "0.4"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+windows-sys = { version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,8 +3,8 @@ name = "audioipc2-server"
 version = "0.5.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
-        "Dan Glastonbury <dan.glastonbury@gmail.com>"
-        ]
+        "Dan Glastonbury <dan.glastonbury@gmail.com>",
+]
 license = "ISC"
 description = "Remote cubeb server"
 edition = "2018"
@@ -15,12 +15,8 @@ cubeb-core = "0.10.0"
 once_cell = "1.2.0"
 log = "0.4"
 slab = "0.4"
+audio_thread_priority = "0.26"
 
 [dependencies.error-chain]
 version = "0.12.0"
 default-features = false
-
-[dependencies.audio_thread_priority]
-version = "0.26.1"
-default-features = false
-features = ["winapi"]


### PR DESCRIPTION
[Now that windows-sys can be imported to Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1853084), switch AudioIPC from winapi to windows-sys.  Required changes are largely mechanical, but `HANDLE` changes from a `* c_void` to an `isize`, so casts have changed in a couple of places.