### PR TITLE
Bump cubeb to 0.12 and handle ABI changes

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioipc2"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
         "Dan Glastonbury <dan.glastonbury@gmail.com>",
@@ -13,7 +13,7 @@ edition = "2018"
 bincode = "1.3"
 byteorder = "1"
 bytes = "1"
-cubeb = "0.10"
+cubeb = "0.12"
 log = "0.4"
 serde = "1"
 serde_derive = "1"

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -34,7 +34,7 @@ version = "0.30"
 default-features = false
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48", features = [
+windows-sys = { version = "0.52", features = [
         "Win32_Foundation",
         "Win32_Security",
         "Win32_Storage_FileSystem",

--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -34,7 +34,7 @@ version = "0.30"
 default-features = false
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.48", features = [
         "Win32_Foundation",
         "Win32_Security",
         "Win32_Storage_FileSystem",

--- a/audioipc/src/ipccore.rs
+++ b/audioipc/src/ipccore.rs
@@ -25,7 +25,7 @@ use std::fmt::Debug;
 
 const WAKE_TOKEN: Token = Token(!0);
 
-thread_local!(static IN_EVENTLOOP: std::cell::RefCell<Option<thread::ThreadId>> = std::cell::RefCell::new(None));
+thread_local!(static IN_EVENTLOOP: std::cell::RefCell<Option<thread::ThreadId>> = const { std::cell::RefCell::new(None) });
 
 fn assert_not_in_event_loop_thread() {
     IN_EVENTLOOP.with(|b| {

--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -209,6 +209,7 @@ pub enum ServerMessage {
     ContextGetMaxChannelCount,
     ContextGetMinLatency(StreamParams),
     ContextGetPreferredSampleRate,
+    ContextGetSupportedInputProcessingParams,
     ContextGetDeviceEnumeration(ffi::cubeb_device_type),
     ContextSetupDeviceCollectionCallback,
     ContextRegisterDeviceCollectionChanged(ffi::cubeb_device_type, bool),
@@ -225,6 +226,8 @@ pub enum ServerMessage {
     StreamSetVolume(usize, f32),
     StreamSetName(usize, CString),
     StreamGetCurrentDevice(usize),
+    StreamSetInputMute(usize, bool),
+    StreamSetInputProcessingParams(usize, ffi::cubeb_input_processing_params),
     StreamRegisterDeviceChangeCallback(usize, bool),
 
     #[cfg(target_os = "linux")]
@@ -242,6 +245,7 @@ pub enum ClientMessage {
     ContextMaxChannelCount(u32),
     ContextMinLatency(u32),
     ContextPreferredSampleRate(u32),
+    ContextSupportedInputProcessingParams(ffi::cubeb_input_processing_params),
     ContextEnumeratedDevices(Vec<DeviceInfo>),
     ContextSetupDeviceCollectionCallback(RegisterDeviceCollectionChanged),
     ContextRegisteredDeviceCollectionChanged,
@@ -258,6 +262,8 @@ pub enum ClientMessage {
     StreamVolumeSet,
     StreamNameSet,
     StreamCurrentDevice(Device),
+    StreamInputMuteSet,
+    StreamInputProcessingParamsSet,
     StreamRegisterDeviceChangeCallback,
 
     #[cfg(target_os = "linux")]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioipc2-client"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
         "Dan Glastonbury <dan.glastonbury@gmail.com>",
@@ -11,6 +11,6 @@ edition = "2018"
 
 [dependencies]
 audioipc = { package = "audioipc2", path = "../audioipc" }
-cubeb-backend = "0.10"
+cubeb-backend = "0.12"
 log = "0.4"
 audio_thread_priority = { version = "0.30", default-features = false }

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -17,8 +17,8 @@ use audioipc::{
     ServerMessage,
 };
 use cubeb_backend::{
-    capi_new, ffi, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceType, Error, Ops,
-    Result, Stream, StreamParams, StreamParamsRef,
+    capi_new, ffi, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceType, Error,
+    InputProcessingParams, Ops, Result, Stream, StreamParams, StreamParamsRef,
 };
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
@@ -237,6 +237,14 @@ impl ContextOps for ClientContext {
     fn preferred_sample_rate(&mut self) -> Result<u32> {
         assert_not_in_callback();
         send_recv!(self.rpc(), ContextGetPreferredSampleRate => ContextPreferredSampleRate())
+    }
+
+    fn supported_input_processing_params(&mut self) -> Result<InputProcessingParams> {
+        assert_not_in_callback();
+        send_recv!(self.rpc(),
+                   ContextGetSupportedInputProcessingParams =>
+                   ContextSupportedInputProcessingParams())
+        .map(InputProcessingParams::from_bits_truncate)
     }
 
     fn enumerate_devices(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -18,8 +18,8 @@ use audioipc::PlatformHandleType;
 use cubeb_backend::{capi, ffi};
 use std::os::raw::{c_char, c_int};
 
-thread_local!(static IN_CALLBACK: std::cell::RefCell<bool> = std::cell::RefCell::new(false));
-thread_local!(static AUDIOIPC_INIT_PARAMS: std::cell::RefCell<Option<AudioIpcInitParams>> = std::cell::RefCell::new(None));
+thread_local!(static IN_CALLBACK: std::cell::RefCell<bool> = const { std::cell::RefCell::new(false) });
+thread_local!(static AUDIOIPC_INIT_PARAMS: std::cell::RefCell<Option<AudioIpcInitParams>> = const { std::cell::RefCell::new(None) });
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -9,7 +9,7 @@ use audioipc::messages::StreamCreateParams;
 use audioipc::messages::{self, CallbackReq, CallbackResp, ClientMessage, ServerMessage};
 use audioipc::shm::SharedMem;
 use audioipc::{rpccore, sys};
-use cubeb_backend::{ffi, DeviceRef, Error, Result, Stream, StreamOps};
+use cubeb_backend::{ffi, DeviceRef, Error, InputProcessingParams, Result, Stream, StreamOps};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 use std::ptr;
@@ -300,6 +300,18 @@ impl StreamOps for ClientStream<'_> {
             Ok(d) => Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(Box::new(d.into()))) }),
             Err(e) => Err(e),
         }
+    }
+
+    fn set_input_mute(&mut self, mute: bool) -> Result<()> {
+        assert_not_in_callback();
+        let rpc = self.context.rpc();
+        send_recv!(rpc, StreamSetInputMute(self.token, mute) => StreamInputMuteSet)
+    }
+
+    fn set_input_processing_params(&mut self, params: InputProcessingParams) -> Result<()> {
+        assert_not_in_callback();
+        let rpc = self.context.rpc();
+        send_recv!(rpc, StreamSetInputProcessingParams(self.token, params.bits()) => StreamInputProcessingParamsSet)
     }
 
     fn device_destroy(&mut self, device: &DeviceRef) -> Result<()> {

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.48", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
 ] }

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48", features = [
+windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
 ] }

--- a/ipctest/Cargo.toml
+++ b/ipctest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipctest"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Dan Glastonbury <dan.glastonbury@gmail.com>"]
 license = "ISC"
 edition = "2018"
@@ -9,7 +9,7 @@ edition = "2018"
 audioipc = { package = "audioipc2", path = "../audioipc" }
 audioipc-client = { package = "audioipc2-client", path = "../client" }
 audioipc-server = { package = "audioipc2-server", path = "../server" }
-cubeb = "0.10.0"
+cubeb = "0.12.0"
 env_logger = "0.9"
 error-chain = "0.12.0"
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioipc2-server"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
         "Dan Glastonbury <dan.glastonbury@gmail.com>",
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 audioipc = { package = "audioipc2", path = "../audioipc" }
-cubeb-core = "0.10.0"
+cubeb-core = "0.12.0"
 once_cell = "1.2.0"
 log = "0.4"
 slab = "0.4"

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -154,7 +154,7 @@ struct CubebContextState {
     context: cubeb::Result<cubeb::Context>,
 }
 
-thread_local!(static CONTEXT_KEY: RefCell<Option<CubebContextState>> = RefCell::new(None));
+thread_local!(static CONTEXT_KEY: RefCell<Option<CubebContextState>> = const { RefCell::new(None) });
 
 fn cubeb_init_from_context_params() -> cubeb::Result<cubeb::Context> {
     let params = super::G_CUBEB_CONTEXT_PARAMS.lock().unwrap();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -13,6 +13,7 @@ use audioipc::messages::{
 };
 use audioipc::shm::SharedMem;
 use audioipc::{ipccore, rpccore, sys, PlatformHandle};
+use cubeb::InputProcessingParams;
 use cubeb_core as cubeb;
 use cubeb_core::ffi;
 use std::convert::{From, TryInto};
@@ -509,6 +510,11 @@ impl CubebServer {
                 .map(ClientMessage::ContextPreferredSampleRate)
                 .unwrap_or_else(error),
 
+            ServerMessage::ContextGetSupportedInputProcessingParams => context
+                .supported_input_processing_params()
+                .map(|params| ClientMessage::ContextSupportedInputProcessingParams(params.bits()))
+                .unwrap_or_else(error),
+
             ServerMessage::ContextGetDeviceEnumeration(device_type) => context
                 .enumerate_devices(cubeb::DeviceType::from_bits_truncate(device_type))
                 .map(|devices| {
@@ -584,6 +590,18 @@ impl CubebServer {
                 .current_device()
                 .map(|device| ClientMessage::StreamCurrentDevice(Device::from(device)))
                 .unwrap_or_else(error),
+
+            ServerMessage::StreamSetInputMute(stm_tok, mute) => try_stream!(self, stm_tok)
+                .set_input_mute(mute)
+                .map(|_| ClientMessage::StreamInputMuteSet)
+                .unwrap_or_else(error),
+
+            ServerMessage::StreamSetInputProcessingParams(stm_tok, params) => {
+                try_stream!(self, stm_tok)
+                    .set_input_processing_params(InputProcessingParams::from_bits_truncate(params))
+                    .map(|_| ClientMessage::StreamInputProcessingParamsSet)
+                    .unwrap_or_else(error)
+            }
 
             ServerMessage::StreamRegisterDeviceChangeCallback(stm_tok, enable) => {
                 try_stream!(self, stm_tok)


### PR DESCRIPTION
Besides the ABI change adaptations, this PR also temporarily moves windows-sys back to 0.48 and re-bumps it, such that there is a rev that can easily be merged into gecko (which doesn't have windows-sys 0.52 yet); and fixes some warnings with the latest nightly toolchain in order to green up CI.