### PR TITLE
Handle data callbacks of size zero

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -260,6 +260,11 @@ impl ServerStreamCallbacks {
             return cubeb::ffi::CUBEB_ERROR.try_into().unwrap();
         }
 
+        if nframes == 0 {
+            // Optimization: skip the RPC call when there are no frames.
+            return 0;
+        }
+
         let r = self.data_callback_rpc.call(CallbackReq::Data {
             nframes,
             input_frame_size: self.input_frame_size as usize,


### PR DESCRIPTION
The client side does not allow CallbackData::Req of size zero. This handles it on the server side by returning early.

The background for this is https://bugzilla.mozilla.org/show_bug.cgi?id=1907367 where something is causing data callbacks of size zero and tripping an assertion, but we have not reproduced and an audit is not conclusive as to where the root cause is.